### PR TITLE
Added a setting to hide / remove numbers from filenames

### DIFF
--- a/app/src/main/kotlin/com/neilturner/aerialviews/models/prefs/GeneralPrefs.kt
+++ b/app/src/main/kotlin/com/neilturner/aerialviews/models/prefs/GeneralPrefs.kt
@@ -23,6 +23,7 @@ object GeneralPrefs : KotprefModel() {
     var philipsDolbyVisionFix by booleanPref(false, "philips_dolby_vision_fix")
 
     var filenameAsLocation by booleanPref(true, "any_videos_filename_location")
+    var hideNumbersFromFilename by booleanPref(false, "any_videos_filename_hide_numbers")
     var useAppleManifests by booleanPref(true, "any_videos_use_apple_manifests")
     var useCustomManifests by booleanPref(true, "any_videos_use_custom_manifests")
     var ignoreNonManifestVideos by booleanPref(false, "any_videos_ignore_non_manifest_videos")

--- a/app/src/main/kotlin/com/neilturner/aerialviews/services/VideoService.kt
+++ b/app/src/main/kotlin/com/neilturner/aerialviews/services/VideoService.kt
@@ -95,7 +95,10 @@ class VideoService(private val context: Context) {
         ) {
             videos.forEach { video ->
                 if (video.location.isBlank()) {
-                    val location = FileHelper.filenameToTitleCase(video.uri)
+                    var location = FileHelper.filenameToTitleCase(video.uri)
+                    if (GeneralPrefs.hideNumbersFromFilename) {
+                        location = location.replace(Regex("[0-9]"), "")
+                    }
                     video.location = location
                 }
             }

--- a/app/src/main/kotlin/com/neilturner/aerialviews/ui/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/neilturner/aerialviews/ui/settings/SettingsFragment.kt
@@ -186,6 +186,7 @@ class SettingsFragment :
             // GeneralPrefs.bufferingStrategy = properties["performance_buffering_strategy"] as String
 
             GeneralPrefs.filenameAsLocation = properties["any_videos_filename_location"].toString().toBoolean()
+            GeneralPrefs.hideNumbersFromFilename = properties["any_videos_filename_hide_numbers"].toString().toBoolean()
             GeneralPrefs.useAppleManifests = properties["any_videos_use_apple_manifests"].toString().toBoolean()
             GeneralPrefs.useCustomManifests = properties["any_videos_use_custom_manifests"].toString().toBoolean()
             GeneralPrefs.ignoreNonManifestVideos = properties["any_videos_ignore_non_manifest_videos"].toString().toBoolean()
@@ -255,6 +256,7 @@ class SettingsFragment :
         // settings["performance_buffering_strategy"] = GeneralPrefs.bufferingStrategy
 
         settings["any_videos_filename_location"] = GeneralPrefs.filenameAsLocation.toString()
+        settings["any_videos_filename_hide_numbers"] = GeneralPrefs.hideNumbersFromFilename.toString()
         settings["any_videos_use_apple_manifests"] = GeneralPrefs.useAppleManifests.toString()
         settings["any_videos_use_custom_manifests"] = GeneralPrefs.useCustomManifests.toString()
         settings["any_videos_ignore_non_manifest_videos"] = GeneralPrefs.ignoreNonManifestVideos.toString()

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -155,6 +155,9 @@
     <string name="any_videos_filename_location_title">Nutze Dateinamen als Ortsangabe</string>
     <string name="any_videos_filename_location_summary">Beispiel: \'Stadt-ein_ort.mp4\' wird als \'Stadt - Ein Ort\' angezeigt</string>
 
+    <string name="any_videos_filename_hide_numbers_title">Zahlen im Dateinamen ausblenden</string>
+    <string name="any_videos_filename_hide_numbers_summary">Bei Verwendung des Dateinamens als Speicherort, \'Stadt_2.mp4\' wird als \'Stadt\'</string>
+
     <string name="refresh_rate_switching_title">Automatische Bildwiederholungsrate</string>
     <string name="refresh_rate_switching_summary">Passe die Bildwiederholungsrate des Displays an die Videoframerate an</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -155,6 +155,9 @@
     <string name="any_videos_filename_location_title">Utiliser les noms de fichiers comme emplacement</string>
     <string name="any_videos_filename_location_summary">Exemple: «ville-un_endroit.mp4» est affiché comme «ville - un endroit»</string>
 
+    <string name="any_videos_filename_hide_numbers_title">Masquer les numéros dans le nom du fichier</string>
+    <string name="any_videos_filename_hide_numbers_summary">Lors de l\'utilisation du nom de fichier comme emplacement, «ville-2.mp4» est affiché comme «Ville»</string>
+
     <string name="refresh_rate_switching_title">Auto refresh rate switching</string>
     <string name="refresh_rate_switching_summary">Change the refresh rate of the display to match the video frame rate</string>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -156,6 +156,9 @@
     <string name="any_videos_filename_location_title">Имя файла в качестве местоположения</string>
     <string name="any_videos_filename_location_summary">"напр. 'country-a_place.mp4' станет 'Country - A Place'"</string>
 
+    <string name="any_videos_filename_hide_numbers_title">Скрыть цифры в имени файла</string>
+    <string name="any_videos_filename_hide_numbers_summary">При использовании имени файла в качестве местоположения, e.g. \'country_2.mp4\' станет \'Country\'</string>
+
     <string name="refresh_rate_switching_title">Auto refresh rate switching</string>
     <string name="refresh_rate_switching_summary">Change the refresh rate of the display to match the video frame rate</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -156,6 +156,9 @@
     <string name="any_videos_filename_location_title">Use filename as location</string>
     <string name="any_videos_filename_location_summary">eg. \'country-a_place.mp4\' becomes \'Country - A Place\'</string>
 
+    <string name="any_videos_filename_hide_numbers_title">Hide numbers in filename</string>
+    <string name="any_videos_filename_hide_numbers_summary">When using filename as location, e.g. \'country_2.mp4\' becomes \'Country\'</string>
+
     <string name="refresh_rate_switching_title">Auto refresh rate switching</string>
     <string name="refresh_rate_switching_summary">Change the refresh rate of the display to match the video frame rate</string>
 

--- a/app/src/main/res/xml/settings_appearance.xml
+++ b/app/src/main/res/xml/settings_appearance.xml
@@ -29,5 +29,11 @@
                     app:key="any_videos_filename_location"
                     app:title="@string/any_videos_filename_location_title"
                     app:summary="@string/any_videos_filename_location_summary" />
+
+                <CheckBoxPreference
+                    app:defaultValue="false"
+                    app:key="any_videos_filename_hide_numbers"
+                    app:title="@string/any_videos_filename_hide_numbers_title"
+                    app:summary="@string/any_videos_filename_hide_numbers_summary" />
         </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
I wrote a script to grab all the Apple videos and use the accessibility text as the filename (with a number appended for duplicates). I added this setting to hide the number from Location display.

As I was writing it, saw that you can just use the original filename from Apple and the app will match that to info from the manifest though (oops!) Figured I'd still make this PR, and see if it makes sense to add?