### PR TITLE
F-Droid flavor (without Google's Firebase)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -115,16 +115,24 @@ android {
     productFlavors {
         register("github") {
             dimension = "version"
+            buildConfigField 'boolean', 'FIREBASE_AVAILABLE', 'true'
         }
         register("beta") {
             dimension = "version"
             versionNameSuffix = "-beta3"
+            buildConfigField 'boolean', 'FIREBASE_AVAILABLE', 'true'
         }
         register("googleplay") {
             dimension = "version"
+            buildConfigField 'boolean', 'FIREBASE_AVAILABLE', 'true'
         }
         register("amazon") {
             dimension = "version"
+            buildConfigField 'boolean', 'FIREBASE_AVAILABLE', 'true'
+        }
+        register("fdroid") {
+            dimension = "version"
+            buildConfigField 'boolean', 'FIREBASE_AVAILABLE', 'false'
         }
     }
 }
@@ -145,10 +153,17 @@ dependencies {
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("androidx.appcompat:appcompat:1.7.0")
 
-    // Firebase
-    implementation('com.google.firebase:firebase-analytics-ktx:22.1.0')
-    implementation("com.google.firebase:firebase-crashlytics-ktx:19.0.3")
-    implementation("com.google.firebase:firebase-perf-ktx:21.0.1")
+    // Firebase (flavor-based conditional implementation)
+    def firebase = [
+            "com.google.firebase:firebase-analytics-ktx:22.1.0",
+            "com.google.firebase:firebase-crashlytics-ktx:19.0.3",
+            "com.google.firebase:firebase-perf-ktx:21.0.1",
+    ]
+    githubImplementation(firebase)
+    betaImplementation(firebase)
+    googleplayImplementation(firebase)
+    amazonImplementation(firebase)
+    // fdroidImplementation() <- no firebase in F-Droid :)
 
     // Retrofit, OkHttp, and Moshi
     implementation("com.squareup.retrofit2:retrofit:2.11.0")

--- a/app/src/amazon/java/com/neilturner/aerialviews/firebase/Firebase.kt
+++ b/app/src/amazon/java/com/neilturner/aerialviews/firebase/Firebase.kt
@@ -1,0 +1,17 @@
+package com.neilturner.aerialviews.firebase;
+
+import androidx.annotation.NonNull
+import com.google.firebase.analytics.analytics
+import com.google.firebase.crashlytics.crashlytics
+import com.google.firebase.Firebase as googleFirebase
+
+class Firebase () {
+    object crashlytics {
+        fun recordException(@NonNull throwable: Throwable) {
+            googleFirebase.crashlytics.recordException(throwable)
+        }
+    }
+    companion object {
+        val analytics = googleFirebase.analytics
+    }
+}

--- a/app/src/amazon/java/com/neilturner/aerialviews/firebase/FirebaseAnalytics.kt
+++ b/app/src/amazon/java/com/neilturner/aerialviews/firebase/FirebaseAnalytics.kt
@@ -1,0 +1,18 @@
+package com.neilturner.aerialviews.firebase
+
+import com.google.firebase.analytics.FirebaseAnalytics as google_FirebaseAnalytics
+
+class FirebaseAnalytics {
+    class Param :google_FirebaseAnalytics.Param() {
+        companion object {
+            val SCREEN_NAME = google_FirebaseAnalytics.Param.SCREEN_NAME
+            val SCREEN_CLASS = google_FirebaseAnalytics.Param.SCREEN_CLASS
+        }
+    }
+
+    class Event :google_FirebaseAnalytics.Event() {
+        companion object {
+            val SCREEN_VIEW = google_FirebaseAnalytics.Event.SCREEN_VIEW
+        }
+    }
+}

--- a/app/src/beta/java/com/neilturner/aerialviews/firebase/Firebase.kt
+++ b/app/src/beta/java/com/neilturner/aerialviews/firebase/Firebase.kt
@@ -1,0 +1,17 @@
+package com.neilturner.aerialviews.firebase;
+
+import androidx.annotation.NonNull
+import com.google.firebase.analytics.analytics
+import com.google.firebase.crashlytics.crashlytics
+import com.google.firebase.Firebase as googleFirebase
+
+class Firebase () {
+    object crashlytics {
+        fun recordException(@NonNull throwable: Throwable) {
+            googleFirebase.crashlytics.recordException(throwable)
+        }
+    }
+    companion object {
+        val analytics = googleFirebase.analytics
+    }
+}

--- a/app/src/beta/java/com/neilturner/aerialviews/firebase/FirebaseAnalytics.kt
+++ b/app/src/beta/java/com/neilturner/aerialviews/firebase/FirebaseAnalytics.kt
@@ -1,0 +1,18 @@
+package com.neilturner.aerialviews.firebase
+
+import com.google.firebase.analytics.FirebaseAnalytics as google_FirebaseAnalytics
+
+class FirebaseAnalytics {
+    class Param :google_FirebaseAnalytics.Param() {
+        companion object {
+            val SCREEN_NAME = google_FirebaseAnalytics.Param.SCREEN_NAME
+            val SCREEN_CLASS = google_FirebaseAnalytics.Param.SCREEN_CLASS
+        }
+    }
+
+    class Event :google_FirebaseAnalytics.Event() {
+        companion object {
+            val SCREEN_VIEW = google_FirebaseAnalytics.Event.SCREEN_VIEW
+        }
+    }
+}

--- a/app/src/fdroid/java/com/neilturner/aerialviews/firebase/Firebase.kt
+++ b/app/src/fdroid/java/com/neilturner/aerialviews/firebase/Firebase.kt
@@ -1,0 +1,16 @@
+package com.neilturner.aerialviews.firebase;
+
+import android.os.Bundle
+import androidx.annotation.NonNull
+
+class Firebase () {
+    object crashlytics {
+        fun recordException(@NonNull throwable: Throwable) {
+        }
+    }
+
+    object analytics {
+        fun logEvent(x: String, bundle: Bundle) {
+        }
+    }
+}

--- a/app/src/fdroid/java/com/neilturner/aerialviews/firebase/FirebaseAnalytics.kt
+++ b/app/src/fdroid/java/com/neilturner/aerialviews/firebase/FirebaseAnalytics.kt
@@ -1,0 +1,16 @@
+package com.neilturner.aerialviews.firebase
+
+class FirebaseAnalytics {
+    class Param {
+        companion object {
+            val SCREEN_NAME = "SCREEN_NAME"
+            val SCREEN_CLASS = "SCREEN_NAME"
+        }
+    }
+
+    class Event {
+        companion object {
+            val SCREEN_VIEW = "SCREEN_VIEW"
+        }
+    }
+}

--- a/app/src/github/java/com/neilturner/aerialviews/firebase/Firebase.kt
+++ b/app/src/github/java/com/neilturner/aerialviews/firebase/Firebase.kt
@@ -1,0 +1,17 @@
+package com.neilturner.aerialviews.firebase;
+
+import androidx.annotation.NonNull
+import com.google.firebase.analytics.analytics
+import com.google.firebase.crashlytics.crashlytics
+import com.google.firebase.Firebase as googleFirebase
+
+class Firebase () {
+    object crashlytics {
+        fun recordException(@NonNull throwable: Throwable) {
+            googleFirebase.crashlytics.recordException(throwable)
+        }
+    }
+    companion object {
+        val analytics = googleFirebase.analytics
+    }
+}

--- a/app/src/github/java/com/neilturner/aerialviews/firebase/FirebaseAnalytics.kt
+++ b/app/src/github/java/com/neilturner/aerialviews/firebase/FirebaseAnalytics.kt
@@ -1,0 +1,18 @@
+package com.neilturner.aerialviews.firebase
+
+import com.google.firebase.analytics.FirebaseAnalytics as google_FirebaseAnalytics
+
+class FirebaseAnalytics {
+    class Param :google_FirebaseAnalytics.Param() {
+        companion object {
+            val SCREEN_NAME = google_FirebaseAnalytics.Param.SCREEN_NAME
+            val SCREEN_CLASS = google_FirebaseAnalytics.Param.SCREEN_CLASS
+        }
+    }
+
+    class Event :google_FirebaseAnalytics.Event() {
+        companion object {
+            val SCREEN_VIEW = google_FirebaseAnalytics.Event.SCREEN_VIEW
+        }
+    }
+}

--- a/app/src/googleplay/java/com/neilturner/aerialviews/firebase/Firebase.kt
+++ b/app/src/googleplay/java/com/neilturner/aerialviews/firebase/Firebase.kt
@@ -1,0 +1,17 @@
+package com.neilturner.aerialviews.firebase;
+
+import androidx.annotation.NonNull
+import com.google.firebase.analytics.analytics
+import com.google.firebase.crashlytics.crashlytics
+import com.google.firebase.Firebase as googleFirebase
+
+class Firebase () {
+    object crashlytics {
+        fun recordException(@NonNull throwable: Throwable) {
+            googleFirebase.crashlytics.recordException(throwable)
+        }
+    }
+    companion object {
+        val analytics = googleFirebase.analytics
+    }
+}

--- a/app/src/googleplay/java/com/neilturner/aerialviews/firebase/FirebaseAnalytics.kt
+++ b/app/src/googleplay/java/com/neilturner/aerialviews/firebase/FirebaseAnalytics.kt
@@ -1,0 +1,18 @@
+package com.neilturner.aerialviews.firebase
+
+import com.google.firebase.analytics.FirebaseAnalytics as google_FirebaseAnalytics
+
+class FirebaseAnalytics {
+    class Param :google_FirebaseAnalytics.Param() {
+        companion object {
+            val SCREEN_NAME = google_FirebaseAnalytics.Param.SCREEN_NAME
+            val SCREEN_CLASS = google_FirebaseAnalytics.Param.SCREEN_CLASS
+        }
+    }
+
+    class Event :google_FirebaseAnalytics.Event() {
+        companion object {
+            val SCREEN_VIEW = google_FirebaseAnalytics.Event.SCREEN_VIEW
+        }
+    }
+}

--- a/app/src/main/java/com/neilturner/aerialviews/ui/sources/SambaVideosFragment.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/ui/sources/SambaVideosFragment.kt
@@ -14,10 +14,9 @@ import androidx.preference.MultiSelectListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceManager
-import com.google.firebase.crashlytics.ktx.crashlytics
-import com.google.firebase.ktx.Firebase
 import com.hierynomus.mssmb2.SMB2Dialect
 import com.neilturner.aerialviews.R
+import com.neilturner.aerialviews.firebase.Firebase
 import com.neilturner.aerialviews.models.prefs.SambaMediaPrefs
 import com.neilturner.aerialviews.providers.SambaMediaProvider
 import com.neilturner.aerialviews.utils.PermissionHelper

--- a/app/src/main/java/com/neilturner/aerialviews/utils/LoggingHelper.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/utils/LoggingHelper.kt
@@ -1,9 +1,9 @@
 package com.neilturner.aerialviews.utils
 
 import androidx.core.os.bundleOf
-import com.google.firebase.analytics.FirebaseAnalytics
-import com.google.firebase.analytics.ktx.analytics
-import com.google.firebase.ktx.Firebase
+import com.neilturner.aerialviews.BuildConfig
+import com.neilturner.aerialviews.firebase.Firebase
+import com.neilturner.aerialviews.firebase.FirebaseAnalytics
 
 object LoggingHelper {
     private val firebaseAnalytics = Firebase.analytics
@@ -12,12 +12,14 @@ object LoggingHelper {
         screenName: String,
         activityName: String,
     ) {
-        val parameters =
-            bundleOf(
-                Pair(FirebaseAnalytics.Param.SCREEN_NAME, screenName),
-                Pair(FirebaseAnalytics.Param.SCREEN_CLASS, activityName),
-            )
+        if (BuildConfig.FIREBASE_AVAILABLE) {
+            val parameters =
+                bundleOf(
+                    Pair(FirebaseAnalytics.Param.SCREEN_NAME, screenName),
+                    Pair(FirebaseAnalytics.Param.SCREEN_CLASS, activityName),
+                )
 
-        firebaseAnalytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW, parameters)
+            firebaseAnalytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW, parameters)
+        }
     }
 }


### PR DESCRIPTION
Fixes #133

Implements`fdroid` gradle flavor without Firebase dependencies.

A new package `com.neilturner.aerialviews.firebase` is defined to hold Firebase conditional implementation. There's an implementation per flavor: 
- `amazon`, `beta`, `github` and `googleplay` use Google's Firebase. App's Gradle imports Firebase for these flavors. 
- `fdroid` uses a dumb implementation that does nothing
