### PR TITLE
RU translation fix

### DIFF
--- a/app/src/main/res/values-ru/arrays.xml
+++ b/app/src/main/res/values-ru/arrays.xml
@@ -6,8 +6,8 @@
   </string-array>
   <string-array name="appearance_font_weight_entries">
     <item>100/Тонкая</item>
-    <item>200/Сверхсветлая</item>
-    <item>300/Светлая (по умолчанию)</item>
+    <item>200/Сверхлегкая</item>
+    <item>300/Легкая (по умолчанию)</item>
     <item>400/Нормальная</item>
     <item>500/Средняя</item>
     <item>600/Полужирная</item>


### PR DESCRIPTION
Corrected translation for "light" and "extra light" into Ru (in the context of weight).