### PR TITLE
Now playing fix

### DIFF
--- a/app/src/main/java/com/neilturner/aerialviews/models/enums/NowPlayingFormat.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/models/enums/NowPlayingFormat.kt
@@ -1,7 +1,7 @@
 package com.neilturner.aerialviews.models.enums
 
 enum class NowPlayingFormat {
-    DISALBED,
+    DISABLED,
     SONG_ARTIST,
     ARTIST_SONG,
     ARTIST,

--- a/app/src/main/java/com/neilturner/aerialviews/models/prefs/GeneralPrefs.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/models/prefs/GeneralPrefs.kt
@@ -35,7 +35,7 @@ object GeneralPrefs : KotprefModel() {
 
     // Music
     var nowPlayingLine1 by nullableEnumValuePref(NowPlayingFormat.SONG_ARTIST, "nowplaying_line1")
-    var nowPlayingLine2 by nullableEnumValuePref(NowPlayingFormat.DISALBED, "nowplaying_line2")
+    var nowPlayingLine2 by nullableEnumValuePref(NowPlayingFormat.DISABLED, "nowplaying_line2")
     var nowPlayingSize by stringPref("18", "nowplaying_size")
     var nowPlayingWeight by stringPref("300", "nowplaying_weight")
 

--- a/app/src/main/java/com/neilturner/aerialviews/ui/overlays/TextNowPlaying.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/ui/overlays/TextNowPlaying.kt
@@ -22,7 +22,7 @@ import me.kosert.flowbus.GlobalBus
 
 class TextNowPlaying : AppCompatTextView {
     var type = OverlayType.MUSIC1
-    var format = NowPlayingFormat.DISALBED
+    var format = NowPlayingFormat.DISABLED
 
     private val coroutineScope = CoroutineScope(Dispatchers.Main)
     private val receiver = EventsReceiver()
@@ -36,7 +36,7 @@ class TextNowPlaying : AppCompatTextView {
     }
 
     fun updateFormat(format: NowPlayingFormat?) {
-        this.format = format ?: NowPlayingFormat.DISALBED
+        this.format = format ?: NowPlayingFormat.DISABLED
     }
 
     @OptIn(FlowPreview::class)

--- a/app/src/main/java/com/neilturner/aerialviews/ui/overlays/TextNowPlaying.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/ui/overlays/TextNowPlaying.kt
@@ -69,8 +69,12 @@ class TextNowPlaying : AppCompatTextView {
     private fun formatNowPlaying(trackInfo: MusicEvent): String {
         val (artist, song) = trackInfo
         return when (format) {
-            NowPlayingFormat.SONG_ARTIST -> "$song · $artist"
-            NowPlayingFormat.ARTIST_SONG -> "$artist · $song"
+            NowPlayingFormat.SONG_ARTIST ->
+                if (song.isNotBlank() && artist.isNotBlank()) "$song · $artist"
+                else song.takeIf { it.isNotBlank() } ?: artist
+            NowPlayingFormat.ARTIST_SONG ->
+                if (artist.isNotBlank() && song.isNotBlank()) "$artist · $song"
+                else artist.takeIf { it.isNotBlank() } ?: song
             NowPlayingFormat.ARTIST -> artist
             NowPlayingFormat.SONG -> song
             else -> ""

--- a/app/src/main/java/com/neilturner/aerialviews/ui/settings/OverlaysNowPlayingFragment.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/ui/settings/OverlaysNowPlayingFragment.kt
@@ -39,10 +39,16 @@ class OverlaysNowPlayingFragment :
 
     private fun openNotificationSettings() {
         try {
-            val intent = Intent("android.settings.ACTION_NOTIFICATION_LISTENER_SETTINGS")
+            val intent = Intent(android.provider.Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS)
             startActivity(intent)
         } catch (ex: Exception) {
             Timber.e(ex, "Unable to open notification settings: ${ex.message}")
+            try {
+                val intent = Intent(android.provider.Settings.ACTION_MANAGE_APPLICATIONS_SETTINGS)
+                startActivity(intent)
+            } catch (ex2: Exception) {
+                Timber.e(ex2, "Unable to open manage application settings: ${ex2.message}")
+            }
         }
     }
 

--- a/app/src/main/java/com/neilturner/aerialviews/ui/settings/OverlaysNowPlayingFragment.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/ui/settings/OverlaysNowPlayingFragment.kt
@@ -3,6 +3,7 @@ package com.neilturner.aerialviews.ui.settings
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import android.widget.Toast
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceManager
@@ -46,6 +47,9 @@ class OverlaysNowPlayingFragment :
             try {
                 val intent = Intent(android.provider.Settings.ACTION_MANAGE_APPLICATIONS_SETTINGS)
                 startActivity(intent)
+
+                val toast = Toast.makeText(requireContext(), R.string.nowplaying_toast_text, Toast.LENGTH_LONG)
+                toast.show()
             } catch (ex2: Exception) {
                 Timber.e(ex2, "Unable to open manage application settings: ${ex2.message}")
             }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -206,6 +206,7 @@
   <string name="nowplaying_permission_notice_summary">Um den Benachrichtigungszugriff zu aktivieren unter Einstellungen &gt; Apps &gt; Spezieller Zugriff &gt; Benachrichtigungszugriff nachsehen</string>
   <string name="nowplaying_permission_summary">Damit diese App Musikbenachrichtigungen vom System anzeigen kann ist eine Berechtigung erforderlich</string>
   <string name="nowplaying_permission_title">Zugriff auf Systembenachrichtigungen aktivieren</string>
+  <string name="nowplaying_toast_text">Gehen zu \"Spezieller App-Zugriff\" > \"Benachrichtigungszugriff\" und aktiviere Aerial Views</string>
   <string name="playlist_allow_media_button_passthrough_summary">Play, Pause, Spulen usw. an die im Hintergrund laufende App weiterleiten, ohne den Bildschirmschoner zu beenden (für Musik)</string>
   <string name="playlist_allow_media_button_passthrough_title">Durchleitung von Medien-Tasten erlauben</string>
   <string name="playlist_allow_playback_speed_change_summary">Ändere die Wiedergabegeschwindigkeit (Hoch / Runter auf dem D-Pad der Fernbedienung)</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -206,6 +206,7 @@
   <string name="nowplaying_permission_notice_summary">Para habilitar el acceso a notificaciones, consulte Configuración &gt; Aplicaciones &gt; Acceso especial &gt; Acceso a notificaciones</string>
   <string name="nowplaying_permission_summary">Se requiere permiso para que esta aplicación pueda escuchar notificaciones de música del sistema</string>
   <string name="nowplaying_permission_title">Habilitar el acceso a las notificaciones del sistema</string>
+  <string name="nowplaying_toast_text">Ve a \"Aplicaciones con accesos especiales\" > \"Acceso a notificaciones\" y activa Aerial Views</string>
   <string name="playlist_allow_media_button_passthrough_summary">Pass-through del botón reproducir, pausa, rebobinar, etc a la aplicación en segundo plano (Por ejemplo: Aplicación de música) sin salir del protector de pantalla</string>
   <string name="playlist_allow_media_button_passthrough_title">Permitir pass-through del botón multimedia</string>
   <string name="playlist_allow_playback_speed_change_summary">Cambie la velocidad del video presionando hacia arriba o hacia abajo en el pad direccional de su control remoto</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -206,6 +206,7 @@
   <string name="nowplaying_permission_notice_summary">Pour activer l\'accès aux notifications, veuillez consulter la rubrique Paramètres &gt; Apps &gt; Special Access &gt; Notification access</string>
   <string name="nowplaying_permission_summary">Cette autorisation est nécessaire pour que l\'application puisse écouter les notifications musicales du système.</string>
   <string name="nowplaying_permission_title">Activer l\'accès à la notification du système</string>
+  <string name="nowplaying_toast_text">Accédez à \"Accès spéciaux des applis\" > \"Accès aux notifications\" et activez Aerial Views</string>
   <string name="playlist_allow_media_button_passthrough_summary">Transmet les pressions sur les boutons de lecture, de pause, de retour en arrière, etc. à l\'application d\'arrière-plan (par exemple, l\'application musicale) sans quitter l\'économiseur d\'écran.</string>
   <string name="playlist_allow_media_button_passthrough_title">Autoriser le passage des boutons de média</string>
   <string name="playlist_allow_playback_speed_change_summary">Modifiez la vitesse de la vidéo en appuyant sur le haut ou le bas du d-pad de votre télécommande.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -206,6 +206,7 @@
   <string name="nowplaying_permission_notice_summary">Per abilitare l\'accesso alle notifiche, cerca in Impostazioni &gt; App &gt; Accesso speciale &gt; Accesso alle notifiche</string>
   <string name="nowplaying_permission_summary">È richiesta l\'autorizzazione affinché questa app possa ascoltare le notifiche musicali dal sistema</string>
   <string name="nowplaying_permission_title">Abilita l\'accesso alle notifiche di sistema</string>
+  <string name="nowplaying_toast_text">Vai su \"Accesso speciale per le app\" > \"Accesso alle notifiche\" e attiva Aerial Views</string>
   <string name="playlist_allow_media_button_passthrough_summary">Passa la pressione dei pulsanti di riproduzione, pausa, riavvolgimento, ecc. all\'applicazione in background (ad esempio, l\'applicazione musicale) senza uscire dallo screensaver.</string>
   <string name="playlist_allow_media_button_passthrough_title">Consenti il pass-through dei tasti multimediali</string>
   <string name="playlist_allow_playback_speed_change_summary">Modifica la velocità del video premendo il d-pad del telecomando verso l\'alto o verso il basso.</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -206,6 +206,7 @@
   <string name="nowplaying_permission_notice_summary">כדי להפעיל גישה להתראות, חפש בהגדרות &gt; אפליקציות &gt; גישה מיוחדת &gt; גישת התראות</string>
   <string name="nowplaying_permission_summary">נדרשת הרשאה כדי שאפליקציה זו תוכל להאזין להודעות מוזיקה מהמערכת</string>
   <string name="nowplaying_permission_title">אפשר גישה להתראות מערכת</string>
+  <string name="nowplaying_toast_text">עבור ל-"גישה מיוחדת לאפליקציה" > "גישה להתראות" והפעל Aerial Views</string>
   <string name="playlist_allow_media_button_passthrough_summary">מעביר לחיצות לחצן של הפעלה, עצירה, החזר אחורה, וכו׳ לאפליקציית הרקע (לדוגמה״ אפליקציית המוסיקה) ללא יציאה משומר המסך</string>
   <string name="playlist_allow_media_button_passthrough_title">הרשה העברה של לחצני מדיה</string>
   <string name="playlist_allow_playback_speed_change_summary">שנה את מהירות הווידאו על ידי לחיצה למעלה או למטה בשלט</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -206,6 +206,7 @@
   <string name="nowplaying_permission_notice_summary">Чтобы включить доступ к уведомлениям, перейдите в Настройки &gt; Приложения &gt; Пользовательский доступ &gt; Доступ к уведомлениям</string>
   <string name="nowplaying_permission_summary">Требуется разрешение, чтобы это приложение могло прослушивать музыкальные уведомления из системы</string>
   <string name="nowplaying_permission_title">Включить доступ к системным уведомлениям</string>
+  <string name="nowplaying_toast_text">Перейдите в \"Специальный доступ\" > \"Доступ к уведомлениям\" и включите Aerial Views</string>
   <string name="playlist_allow_media_button_passthrough_summary">Передаёт нажатия кнопок воспроизведения, паузы, перемотки назад и т.д. в фоновое приложение (например, музыкальное приложение) без выхода из заставки.</string>
   <string name="playlist_allow_media_button_passthrough_title">Разрешить сквозную передачу кнопок мультимедиа</string>
   <string name="playlist_allow_playback_speed_change_summary">Изменяйте скорость видео, нажимая вверх или вниз на крестовине пульта управления</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -206,6 +206,7 @@
   <string name="nowplaying_permission_notice_summary">Щоб увімкнути доступ до сповіщень, перейдіть до Налаштування &gt; Програми &gt; Спеціальний доступ &gt; Доступ до сповіщень</string>
   <string name="nowplaying_permission_summary">Потрібен дозвіл, щоб ця програма могла слухати музичні сповіщення з системи</string>
   <string name="nowplaying_permission_title">Увімкнути доступ до системних повідомлень</string>
+  <string name="nowplaying_toast_text">Перейдіть до \"Спеціальний доступ додатка\" > \"Доступ до сповіщень\" та увімкніть Aerial Views</string>
   <string name="playlist_allow_media_button_passthrough_summary">Передає натискання кнопок відтворення, паузи, перемотування назад тощо у фонову програму (наприклад, музичну програму) без виходу із заставки.</string>
   <string name="playlist_allow_media_button_passthrough_title">Дозволити наскрізну передачу мультимедійних кнопок</string>
   <string name="playlist_allow_playback_speed_change_summary">Змінюйте швидкість відео, натискаючи вгору або вниз на хрестовині пульта управління</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -206,6 +206,7 @@
   <string name="nowplaying_permission_notice_summary">要启用通知访问，请在设置&gt; 应用程序&gt; 特殊访问&gt; 通知访问</string>
   <string name="nowplaying_permission_summary">必须获得许可，此应用程序才能监听来自系统的音乐通知</string>
   <string name="nowplaying_permission_title">启用系统通知访问</string>
+  <string name="nowplaying_toast_text">转到特殊应用权限>通知访问，然后打开 Aerial Views</string>
   <string name="playlist_allow_media_button_passthrough_summary">在不退出屏保的情况下，将按下的播放、暂停、倒带等按钮传递给后台程序（如音乐程序</string>
   <string name="playlist_allow_media_button_passthrough_title">允许媒体按钮直通</string>
   <string name="playlist_allow_playback_speed_change_summary">按遥控器方向键的向上或向下更改视频速度</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -406,7 +406,7 @@
     <string-array name="nowplaying_format_values" translatable="false">
         <item>DISABLED</item>
         <item>SONG_ARTIST</item>
-        <item>ARTIST_ARTIST</item>
+        <item>ARTIST_SONG</item>
         <item>ARTIST</item>
         <item>SONG</item>
     </string-array>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -371,6 +371,8 @@
     <string name="nowplaying_line1_title">Now Playing - Line 1</string>
     <string name="nowplaying_line2_title">Now Playing - Line 2</string>
 
+    <string name="nowplaying_toast_text">Go to \"Special app access\" > \"Notification access\" and turn on Aerial Views</string>
+
     <!-- Unsplash -->
     <!-- Pexels? -->
     <!-- Exif -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -371,7 +371,7 @@
     <string name="nowplaying_line1_title">Now Playing - Line 1</string>
     <string name="nowplaying_line2_title">Now Playing - Line 2</string>
 
-    <string name="nowplaying_toast_text">Go to \"Special app access\" > \"Notification access\" and turn on Aerial Views</string>
+    <string name="nowplaying_toast_text">Please enable Aerial Views in: Special app access > Notification access</string>
 
     <!-- Unsplash -->
     <!-- Pexels? -->


### PR DESCRIPTION
- Fix single delimiter on startup caused empty Media Metadata

![image](https://github.com/user-attachments/assets/f92896ec-c808-4919-bf8a-725e0ba1cf7a)


- Fix namings

- Fixes #169. Open Applications Settings when ActivityNotFoundException for Notification Listener Settings.

Now it opens **notification settings** for devices can open it and **application settings** for other (eg: Nvidia Shield)
![Android TV Emulator with Notification Settings](https://github.com/user-attachments/assets/9e901a36-0619-4ff5-a38d-07b2ac2804a4)
![Nvidia Shield Pro with Application Settings](https://github.com/user-attachments/assets/96eab394-ef27-4908-8a50-0651fee6d9fd)
