### PR TITLE
Common style text fix

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -200,8 +200,8 @@
   <string name="local_videos_shield_notice_summary">Einstellungen &gt; Geräteeinstellungen &gt; Speicher &gt; Automatisch nach Medien durchsuchen</string>
   <string name="local_videos_shield_notice_title">\"Nvidia Shield\"-Nutzer: Bitte folgende Option aktivieren…</string>
   <string name="local_videos_test_results">Testresultate</string>
-  <string name="nowplaying_line1_title">Jetzt läuft - Zeile 1</string>
-  <string name="nowplaying_line2_title">Jetzt läuft - Zeile 2</string>
+  <string name="nowplaying_line1_title">Zeile 1</string>
+  <string name="nowplaying_line2_title">Zeile 2</string>
   <string name="nowplaying_permission_legacy_notice_summary">Diese Funktion ist in älteren Versionen von Android TV nicht verfügbar</string>
   <string name="nowplaying_permission_notice_summary">Um den Benachrichtigungszugriff zu aktivieren unter Einstellungen &gt; Apps &gt; Spezieller Zugriff &gt; Benachrichtigungszugriff nachsehen</string>
   <string name="nowplaying_permission_summary">Damit diese App Musikbenachrichtigungen vom System anzeigen kann ist eine Berechtigung erforderlich</string>

--- a/app/src/main/res/values-es/arrays.xml
+++ b/app/src/main/res/values-es/arrays.xml
@@ -167,8 +167,8 @@
     <item>Reloj</item>
     <item>Ubicación</item>
     <item>Fecha</item>
-    <item>Línea de mensaje 1</item>
-    <item>Línea de mensaje 1</item>
+    <item>Mensaje #1</item>
+    <item>Mensaje #1</item>
     <item>Reproduciendo ahora #1</item>
     <item>Reproduciendo ahora #2</item>
   </string-array>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -200,8 +200,8 @@
   <string name="local_videos_shield_notice_summary">Ajustes &gt; Preferencias de Dispositivo &gt; Almacenamiento &gt; Escanear por multimedia automáticamente</string>
   <string name="local_videos_shield_notice_title">Usuarios de Nvidia Shield, asegúrense que la siguiente opción este activada…</string>
   <string name="local_videos_test_results">Resultados de la prueba</string>
-  <string name="nowplaying_line1_title">Reproduciendo ahora - Línea 1</string>
-  <string name="nowplaying_line2_title">Reproduciendo ahora - Línea 2</string>
+  <string name="nowplaying_line1_title">Línea 1</string>
+  <string name="nowplaying_line2_title">Línea 2</string>
   <string name="nowplaying_permission_legacy_notice_summary">Esta función no está disponible en versiones anteriores de Android TV</string>
   <string name="nowplaying_permission_notice_summary">Para habilitar el acceso a notificaciones, consulte Configuración &gt; Aplicaciones &gt; Acceso especial &gt; Acceso a notificaciones</string>
   <string name="nowplaying_permission_summary">Se requiere permiso para que esta aplicación pueda escuchar notificaciones de música del sistema</string>

--- a/app/src/main/res/values-fr/arrays.xml
+++ b/app/src/main/res/values-fr/arrays.xml
@@ -167,8 +167,8 @@
     <item>Horloge</item>
     <item>Localisation</item>
     <item>Date</item>
-    <item>Ligne de message 1</item>
-    <item>Ligne de message 2</item>
+    <item>Message #1</item>
+    <item>Message #2</item>
     <item>En cours de lecture #1</item>
     <item>En cours de lecture #2</item>
   </string-array>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -200,8 +200,8 @@
   <string name="local_videos_shield_notice_summary">Paramètres &gt; Préférences de l\'appareil &gt; Stockage &gt; Recherche automatique de supports</string>
   <string name="local_videos_shield_notice_title">Utilisateurs de Nvidia Shield, assurez-vous que l\'option suivante est activée…</string>
   <string name="local_videos_test_results">Résultats des tests</string>
-  <string name="nowplaying_line1_title">En cours de lecture - Ligne 1</string>
-  <string name="nowplaying_line2_title">En cours de lecture - Ligne 2</string>
+  <string name="nowplaying_line1_title">Ligne 1</string>
+  <string name="nowplaying_line2_title">Ligne 2</string>
   <string name="nowplaying_permission_legacy_notice_summary">Cette fonction n\'est pas disponible sur les anciennes versions d\'Android TV.</string>
   <string name="nowplaying_permission_notice_summary">Pour activer l\'accès aux notifications, veuillez consulter la rubrique Paramètres &gt; Apps &gt; Special Access &gt; Notification access</string>
   <string name="nowplaying_permission_summary">Cette autorisation est nécessaire pour que l\'application puisse écouter les notifications musicales du système.</string>

--- a/app/src/main/res/values-it/arrays.xml
+++ b/app/src/main/res/values-it/arrays.xml
@@ -167,8 +167,8 @@
     <item>Orologio</item>
     <item>Luogo</item>
     <item>Data</item>
-    <item>Linea messaggio 1</item>
-    <item>Linea messaggio 2</item>
+    <item>Messaggio #1</item>
+    <item>Messaggio #2</item>
     <item>In riproduzione #1</item>
     <item>In riproduzione #2</item>
   </string-array>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -200,8 +200,8 @@
   <string name="local_videos_shield_notice_summary">Impostazioni &gt; Preferenze del dispositivo &gt; Archiviazione &gt; Scansione media automatica</string>
   <string name="local_videos_shield_notice_title">Utenti di Nvidia Shield, assicuratevi che la seguente opzione sia attivata…</string>
   <string name="local_videos_test_results">Risultati del test</string>
-  <string name="nowplaying_line1_title">In riproduzione - Linea 1</string>
-  <string name="nowplaying_line2_title">In riproduzione - Linea 2</string>
+  <string name="nowplaying_line1_title">Linea 1</string>
+  <string name="nowplaying_line2_title">Linea 2</string>
   <string name="nowplaying_permission_legacy_notice_summary">Questa funzionalità non è disponibile sulle versioni precedenti di Android TV</string>
   <string name="nowplaying_permission_notice_summary">Per abilitare l\'accesso alle notifiche, cerca in Impostazioni &gt; App &gt; Accesso speciale &gt; Accesso alle notifiche</string>
   <string name="nowplaying_permission_summary">È richiesta l\'autorizzazione affinché questa app possa ascoltare le notifiche musicali dal sistema</string>

--- a/app/src/main/res/values-ru/arrays.xml
+++ b/app/src/main/res/values-ru/arrays.xml
@@ -169,8 +169,8 @@
     <item>Дата</item>
     <item>Сообщение - Строка 1</item>
     <item>Сообщение - Строка 2</item>
-    <item>Сейчас играет #1</item>
-    <item>Сейчас играет #2</item>
+    <item>Сейчас играет - Строка 1</item>
+    <item>Сейчас играет - Строка 2</item>
   </string-array>
   <string-array name="text_size_entries">
     <item>36sp</item>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -200,8 +200,8 @@
   <string name="local_videos_shield_notice_summary">Настройки &gt; Настройки устройства &gt; Хранилище &gt; Автоматическое сканирование медиафайлов</string>
   <string name="local_videos_shield_notice_title">Пользователи Nvidia Shield, убедитесь, что включена следующая опция…</string>
   <string name="local_videos_test_results">Результаты теста</string>
-  <string name="nowplaying_line1_title">Сейчас играет - Линия 1</string>
-  <string name="nowplaying_line2_title">Сейчас играет - Линия 2</string>
+  <string name="nowplaying_line1_title">Строка 1</string>
+  <string name="nowplaying_line2_title">Строка 2</string>
   <string name="nowplaying_permission_legacy_notice_summary">Эта функция недоступна в старых версиях Android TV</string>
   <string name="nowplaying_permission_notice_summary">Чтобы включить доступ к уведомлениям, перейдите в Настройки &gt; Приложения &gt; Пользовательский доступ &gt; Доступ к уведомлениям</string>
   <string name="nowplaying_permission_summary">Требуется разрешение, чтобы это приложение могло прослушивать музыкальные уведомления из системы</string>

--- a/app/src/main/res/values-uk/arrays.xml
+++ b/app/src/main/res/values-uk/arrays.xml
@@ -169,8 +169,8 @@
     <item>Дата</item>
     <item>Повідомлення - Рядок 1</item>
     <item>Повідомлення - Рядок 2</item>
-    <item>Тепер граємо #1</item>
-    <item>Тепер граємо #2</item>
+    <item>Зараз грає- Рядок 1</item>
+    <item>Зараз грає - Рядок 2</item>
   </string-array>
   <string-array name="text_size_entries">
     <item>36sp</item>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -200,8 +200,8 @@
   <string name="local_videos_shield_notice_summary">Налаштування &gt; Налаштування пристрою &gt; Сховище &gt; Автоматичне сканування медіафайлів</string>
   <string name="local_videos_shield_notice_title">Користувачі Nvidia Shield, переконайтеся, що включена наступна опція…</string>
   <string name="local_videos_test_results">Результати випробувань</string>
-  <string name="nowplaying_line1_title">Зараз граємо - Лінія 1</string>
-  <string name="nowplaying_line2_title">Зараз граємо - Лінія 2</string>
+  <string name="nowplaying_line1_title">Рядок 1</string>
+  <string name="nowplaying_line2_title">Рядок 2</string>
   <string name="nowplaying_permission_legacy_notice_summary">Ця функція недоступна у старих версіях Android TV</string>
   <string name="nowplaying_permission_notice_summary">Щоб увімкнути доступ до сповіщень, перейдіть до Налаштування &gt; Програми &gt; Спеціальний доступ &gt; Доступ до сповіщень</string>
   <string name="nowplaying_permission_summary">Потрібен дозвіл, щоб ця програма могла слухати музичні сповіщення з системи</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -396,8 +396,8 @@
     <string name="nowplaying_permission_legacy_notice_summary">This feature is not available on older versions of Android TV</string>
     <string name="nowplaying_permission_notice_summary">To enable Notification access, please look in Settings > Apps > Special Access > Notification access</string>
 
-    <string name="nowplaying_line1_title">Now Playing - Line 1</string>
-    <string name="nowplaying_line2_title">Now Playing - Line 2</string>
+    <string name="nowplaying_line1_title">Line 1</string>
+    <string name="nowplaying_line2_title">Line 2</string>
 
     <string name="nowplaying_toast_text">Please enable Aerial Views in: Special app access > Notification access</string>
 


### PR DESCRIPTION
- Made the text "line 1" and "line 2" look the same for the overlays **message** and **playing now**
![image](https://github.com/user-attachments/assets/2aa149bc-8418-46ae-bc64-4c39d8d1e054)

- Removed now plays from the line title, as this is duplicate information (like it is in the message category)
![image](https://github.com/user-attachments/assets/07b5302e-c325-4a87-9fbe-981ca79a5225)

- Minor corrections in ru and uk localizations