### PR TITLE
Update Google TV directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Navigate to the Settings menu on your device, then to the About screen. Dependin
 
 Scroll down to __Build__ and select __Build__ several times until you get the message "You are now a developer!"
 
-Return to __Settings__ and look for the newly enabled __Developer options__ page.
+Return to __Settings__ or __Settings > System__ and look for the newly enabled __Developer options__ page.
 
 On the __Developer options__ page, look for the __USB debugging__ option and enable it.
 


### PR DESCRIPTION
Update to match the menu which had the setting on my device

Android TV OS OS version 14
Kernel version 5.15.153-android14-11-maybe-dirty
Android TV OS build UTTC.241218.008.H1.13427172