### PR TITLE
feat: add more options for slideshow speed

### DIFF
--- a/app/src/main/res/values-es/arrays.xml
+++ b/app/src/main/res/values-es/arrays.xml
@@ -225,6 +225,9 @@
     <item>3 minutos</item>
     <item>5 minutos</item>
     <item>10 minutos</item>
+    <item>20 minutos</item>
+    <item>30 minutos</item>
+    <item>1 hora</item>
   </string-array>
   <string-array name="slot_entries">
     <item>Vacío</item>

--- a/app/src/main/res/values-fr/arrays.xml
+++ b/app/src/main/res/values-fr/arrays.xml
@@ -225,6 +225,9 @@
     <item>3 minutes</item>
     <item>5 minutes</item>
     <item>10 minutes</item>
+    <item>20 minutes</item>
+    <item>30 minutes</item>
+    <item>1 heure</item>
   </string-array>
   <string-array name="slot_entries">
     <item>Vide</item>

--- a/app/src/main/res/values-it/arrays.xml
+++ b/app/src/main/res/values-it/arrays.xml
@@ -218,13 +218,16 @@
     <item>5 secondi</item>
     <item>10 secondi</item>
     <item>30 secondi (Predefinito)</item>
-    <item>1 minut0</item>
+    <item>1 minuto</item>
     <item>3 minuti</item>
     <item>5 minuti</item>
     <item>10 minuti</item>
     <item>3 minuti</item>
     <item>5 minuti</item>
     <item>10 minuti</item>
+    <item>20 minuti</item>
+    <item>30 minuti</item>
+    <item>1 ora</item>
   </string-array>
   <string-array name="slot_entries">
     <item>Vuoto</item>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -541,6 +541,9 @@
     <item>3 minutes</item>
     <item>5 minutes</item>
     <item>10 minutes</item>
+    <item>20 minutes</item>
+    <item>30 minutes</item>
+    <item>1 hour</item>
   </string-array>
   <string-array name="slideshow_speed_values" translatable="false">
     <item>5</item>
@@ -553,6 +556,9 @@
     <item>180</item>
     <item>300</item>
     <item>600</item>
+    <item>1200</item>
+    <item>1800</item>
+    <item>3600</item>
   </string-array>
   <string name="slideshow_speed_default" translatable="false">30</string>
 


### PR DESCRIPTION
Add some longer slideshow speed options, up to 1 hour and update corresponding strings for some languages.

I wasn't sure if there was an intentional reason that there weren't longer slideshow speed options (maybe OLED burn-in or something), but I figured the change was small enough that I could just send it and see what you thought.

Testing:
Built and ran app in simulator, opened updated menu. Checked with English and Spanish system language.