### PR TITLE
chore: Update README with ADB commands for app permissions on TCL TVs

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,28 @@ Otherwise, the screensaver cannot be started, either automatically, or manually 
 
 Not all TCL TVs have the same software and features. If the above __Safety Guard__ app does not exist on your TV, the following ADB command might help…
 
+Android <v14:
+
 ```sh
 appops set com.neilturner.aerialviews APP_AUTO_START allow
+```
+
+Androind >=v14
+
+```sh
+appops set com.neilturner.aerialviews AUTO_START allow
+```
+
+You can confirm the available options:
+
+```sh
+appops get com.neilturner.aerialviews
+
+# Returns
+WAKE_LOCK: allow; time=+5m55s466ms ago; duration=+2s889ms
+READ_MEDIA_IMAGES: allow; time=+1m43s406ms ago
+READ_MEDIA_VISUAL_USER_SELECTED: allow; time=+1m43s408ms ago
+AUTO_START: ignore; rejectTime=+7m6s72ms ago
 ```
 
 </details>


### PR DESCRIPTION
In this PR:

- The screensavers don't work after restart.
- Added ADB commands for managing app permissions on TCL TVs.

Debug:

```sh
G16:/ $ appops set com.neilturner.aerialviews APP_AUTO_START allow
Error: Unknown operation string: APP_AUTO_START
255|G16:/ $ appops get com.neilturner.aerialviews
SYSTEM_ALERT_WINDOW: allow
WAKE_LOCK: allow; time=+5m55s466ms ago; duration=+2s889ms
READ_MEDIA_IMAGES: allow; time=+1m43s406ms ago
READ_MEDIA_VISUAL_USER_SELECTED: allow; time=+1m43s408ms ago
AUTO_START: ignore; rejectTime=+7m6s72ms ago
G16:/ $ appops set com.neilturner.aerialviews AUTO_START allow
G16:/ $ appops get com.neilturner.aerialviews
SYSTEM_ALERT_WINDOW: allow
WAKE_LOCK: allow; time=+6m31s889ms ago; duration=+2s889ms
READ_MEDIA_IMAGES: allow; time=+2m19s829ms ago
READ_MEDIA_VISUAL_USER_SELECTED: allow; time=+2m19s831ms ago
AUTO_START: allow; rejectTime=+7m42s495ms ago
```
