### PR TITLE
Smart slideshow clustering for Immich

### DIFF
--- a/app/src/main/java/com/neilturner/aerialviews/models/prefs/ImmichMediaPrefs.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/models/prefs/ImmichMediaPrefs.kt
@@ -45,4 +45,8 @@ object ImmichMediaPrefs : KotprefModel(), ImmichUrlPrefs, ImmichAssetPrefs {
     var includeRecent by stringPref("DISABLED", "immich_media_include_recent")
     override var imageType by nullableEnumValuePref(ImmichImageType.PREVIEW, "immich_media_image_type")
     override var videoType by nullableEnumValuePref(ImmichVideoType.TRANSCODED, "immich_media_video_type")
+    var smartSlideshowEnabled by booleanPref(false, "immich_smart_slideshow_enabled")
+    var smartSlideshowGapMinutes by stringPref("30", "immich_smart_slideshow_gap_minutes")
+    var smartSlideshowExemptAlbumPattern by stringPref("", "immich_smart_slideshow_exempt_pattern")
+    var smartSlideshowExemptPercent by stringPref("100", "immich_smart_slideshow_exempt_percent")
 }

--- a/app/src/main/java/com/neilturner/aerialviews/models/videos/AerialMedia.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/models/videos/AerialMedia.kt
@@ -11,6 +11,11 @@ data class AerialMedia(
     var type: AerialMediaType = AerialMediaType.VIDEO,
     var source: AerialMediaSource = AerialMediaSource.UNKNOWN,
     var metadata: AerialMediaMetadata = AerialMediaMetadata(),
+    // Alternate URIs that belong to the same logical slot (e.g. other members of a
+    // temporal cluster from the Immich smart slideshow). When non-empty, the renderer
+    // picks one at random — including `uri` itself — every time the slot is shown,
+    // so across playlist loops the user sees variety within the cluster.
+    var clusterAlternates: List<Uri> = emptyList(),
 )
 
 data class AerialMediaMetadata(

--- a/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichAssetMapper.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichAssetMapper.kt
@@ -30,7 +30,10 @@ class ImmichAssetMapper(
             }
         }
 
-    fun processAssets(assets: List<Asset>): ProcessResults {
+    fun processAssets(
+        assets: List<Asset>,
+        alternatesByPrimaryId: Map<String, List<Asset>> = emptyMap(),
+    ): ProcessResults {
         val media = mutableListOf<AerialMedia>()
         var excluded = 0
         var videos = 0
@@ -56,6 +59,12 @@ class ImmichAssetMapper(
 
                 val exif = extractExifMetadata(asset)
                 val uri = urlBuilder.getAssetUri(asset.id, isVideo)
+                val altUris =
+                    alternatesByPrimaryId[asset.id]
+                        ?.filter { FileHelper.isSupportedImageType(it.originalPath) == isImage &&
+                                   FileHelper.isSupportedVideoType(it.originalPath) == isVideo }
+                        ?.map { urlBuilder.getAssetUri(it.id, isVideo) }
+                        .orEmpty()
                 val item =
                     AerialMedia(
                         uri,
@@ -64,6 +73,7 @@ class ImmichAssetMapper(
                                 albumName = asset.albumName.orEmpty(),
                                 exif = exif,
                             ),
+                        clusterAlternates = altUris,
                     ).apply {
                         source = AerialMediaSource.IMMICH
                         type = if (isVideo) AerialMediaType.VIDEO else AerialMediaType.IMAGE

--- a/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichClusterer.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichClusterer.kt
@@ -1,0 +1,89 @@
+package com.neilturner.aerialviews.providers.immich
+
+import timber.log.Timber
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+
+object ImmichClusterer {
+    private val parsers =
+        listOf(
+            DateTimeFormatter.ISO_LOCAL_DATE_TIME,
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS"),
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"),
+        )
+
+    fun cluster(
+        assets: List<Asset>,
+        gapMinutes: Int,
+        exemptPattern: Regex? = null,
+        exemptKeepFraction: Double = 1.0,
+    ): List<Asset> {
+        if (assets.isEmpty() || gapMinutes <= 0) return assets
+
+        val exemptAll = mutableListOf<Asset>()
+        val dated = mutableListOf<Pair<Asset, Long>>()
+        val undated = mutableListOf<Asset>()
+
+        for (asset in assets) {
+            if (exemptPattern != null && exemptPattern.containsMatchIn(asset.albumName.orEmpty())) {
+                exemptAll += asset
+                continue
+            }
+            val epoch = asset.localDateTime?.let(::parseEpochSeconds)
+            if (epoch != null) dated += asset to epoch else undated += asset
+        }
+
+        val exemptKept =
+            when {
+                exemptKeepFraction >= 1.0 -> exemptAll
+                exemptKeepFraction <= 0.0 -> emptyList()
+                else -> {
+                    val n = (exemptAll.size * exemptKeepFraction).toInt()
+                    if (n >= exemptAll.size) exemptAll else exemptAll.shuffled().take(n)
+                }
+            }
+
+        dated.sortBy { it.second }
+
+        val gapSeconds = gapMinutes.toLong() * 60
+        val representatives = mutableListOf<Asset>()
+        var clusterStart = 0
+        for (i in 1..dated.size) {
+            val breakHere = i == dated.size || (dated[i].second - dated[i - 1].second) > gapSeconds
+            if (breakHere) {
+                val cluster = dated.subList(clusterStart, i)
+                representatives += cluster.random().first
+                clusterStart = i
+            }
+        }
+
+        representatives += undated
+        representatives += exemptKept
+
+        Timber.i(
+            "ImmichClusterer: %d in → %d clusters + %d undated + %d/%d exempt (gap=%d min, keep=%.2f)",
+            assets.size,
+            representatives.size - undated.size - exemptKept.size,
+            undated.size,
+            exemptKept.size,
+            exemptAll.size,
+            gapMinutes,
+            exemptKeepFraction,
+        )
+
+        return representatives
+    }
+
+    private fun parseEpochSeconds(raw: String): Long? {
+        val normalized = raw.trim().replace(Regex("(?i)(?:z|[+-]\\d{2}:?\\d{2})$"), "")
+        for (parser in parsers) {
+            try {
+                return LocalDateTime.parse(normalized, parser).toEpochSecond(java.time.ZoneOffset.UTC)
+            } catch (_: DateTimeParseException) {
+            }
+        }
+        Timber.w("ImmichClusterer: failed to parse localDateTime '%s'", raw)
+        return null
+    }
+}

--- a/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichClusterer.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichClusterer.kt
@@ -13,13 +13,24 @@ object ImmichClusterer {
             DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"),
         )
 
+    data class Result(
+        val representatives: List<Asset>,
+        /**
+         * Per-cluster alternate members, keyed by representative asset id.
+         * Callers can use this to present variety across playlist loops —
+         * pick a random alternate each time the slot is rendered instead of
+         * freezing the choice at fetch time.
+         */
+        val alternatesByPrimaryId: Map<String, List<Asset>> = emptyMap(),
+    )
+
     fun cluster(
         assets: List<Asset>,
         gapMinutes: Int,
         exemptPattern: Regex? = null,
         exemptKeepFraction: Double = 1.0,
-    ): List<Asset> {
-        if (assets.isEmpty() || gapMinutes <= 0) return assets
+    ): Result {
+        if (assets.isEmpty() || gapMinutes <= 0) return Result(assets)
 
         val exemptAll = mutableListOf<Asset>()
         val dated = mutableListOf<Pair<Asset, Long>>()
@@ -48,12 +59,17 @@ object ImmichClusterer {
 
         val gapSeconds = gapMinutes.toLong() * 60
         val representatives = mutableListOf<Asset>()
+        val alternates = mutableMapOf<String, List<Asset>>()
         var clusterStart = 0
         for (i in 1..dated.size) {
             val breakHere = i == dated.size || (dated[i].second - dated[i - 1].second) > gapSeconds
             if (breakHere) {
-                val cluster = dated.subList(clusterStart, i)
-                representatives += cluster.random().first
+                val clusterAssets = dated.subList(clusterStart, i).map { it.first }
+                val rep = clusterAssets.random()
+                representatives += rep
+                if (clusterAssets.size > 1) {
+                    alternates[rep.id] = clusterAssets.filter { it.id != rep.id }
+                }
                 clusterStart = i
             }
         }
@@ -62,9 +78,10 @@ object ImmichClusterer {
         representatives += exemptKept
 
         Timber.i(
-            "ImmichClusterer: %d in → %d clusters + %d undated + %d/%d exempt (gap=%d min, keep=%.2f)",
+            "ImmichClusterer: %d in → %d clusters (with %d alternates-carrying) + %d undated + %d/%d exempt (gap=%d min, keep=%.2f)",
             assets.size,
             representatives.size - undated.size - exemptKept.size,
+            alternates.size,
             undated.size,
             exemptKept.size,
             exemptAll.size,
@@ -72,7 +89,7 @@ object ImmichClusterer {
             exemptKeepFraction,
         )
 
-        return representatives
+        return Result(representatives, alternates)
     }
 
     private fun parseEpochSeconds(raw: String): Long? {

--- a/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichMediaProvider.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichMediaProvider.kt
@@ -90,7 +90,7 @@ class ImmichMediaProvider(
             return Pair(media, "No files found")
         }
 
-        val assetsForMapping =
+        val clusterResult =
             if (prefs.smartSlideshowEnabled) {
                 val gap = prefs.smartSlideshowGapMinutes.toIntOrNull() ?: 30
                 val exemptPattern =
@@ -107,11 +107,15 @@ class ImmichMediaProvider(
                 val exemptKeep = (prefs.smartSlideshowExemptPercent.toIntOrNull() ?: 100).coerceIn(0, 100) / 100.0
                 ImmichClusterer.cluster(assetResults.allAssets, gap, exemptPattern, exemptKeep)
             } else {
-                assetResults.allAssets
+                ImmichClusterer.Result(assetResults.allAssets)
             }
 
         // Process assets and create media list
-        val processResults = mapper.processAssets(assetsForMapping)
+        val processResults =
+            mapper.processAssets(
+                clusterResult.representatives,
+                clusterResult.alternatesByPrimaryId,
+            )
         media.addAll(processResults.media)
 
         // Build summary message

--- a/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichMediaProvider.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichMediaProvider.kt
@@ -90,8 +90,28 @@ class ImmichMediaProvider(
             return Pair(media, "No files found")
         }
 
+        val assetsForMapping =
+            if (prefs.smartSlideshowEnabled) {
+                val gap = prefs.smartSlideshowGapMinutes.toIntOrNull() ?: 30
+                val exemptPattern =
+                    prefs.smartSlideshowExemptAlbumPattern
+                        .takeIf { it.isNotBlank() }
+                        ?.let {
+                            try {
+                                Regex(it)
+                            } catch (e: Exception) {
+                                Timber.w(e, "Invalid exempt album pattern: '%s'", it)
+                                null
+                            }
+                        }
+                val exemptKeep = (prefs.smartSlideshowExemptPercent.toIntOrNull() ?: 100).coerceIn(0, 100) / 100.0
+                ImmichClusterer.cluster(assetResults.allAssets, gap, exemptPattern, exemptKeep)
+            } else {
+                assetResults.allAssets
+            }
+
         // Process assets and create media list
-        val processResults = mapper.processAssets(assetResults.allAssets)
+        val processResults = mapper.processAssets(assetsForMapping)
         media.addAll(processResults.media)
 
         // Build summary message

--- a/app/src/main/java/com/neilturner/aerialviews/ui/core/ImagePlayerView.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/ui/core/ImagePlayerView.kt
@@ -119,7 +119,18 @@ class ImagePlayerView : FrameLayout {
                 add(buildGifDecoder())
             }.build()
 
-    fun setImage(media: AerialMedia) {
+    fun setImage(mediaParam: AerialMedia) {
+        // If this logical slot carries alternates (e.g. other members of a temporal
+        // cluster from the Immich smart slideshow), pick one at random every time
+        // the slot is rendered so the user sees variety across playlist loops.
+        val media =
+            if (mediaParam.clusterAlternates.isNotEmpty()) {
+                val all = listOf(mediaParam.uri) + mediaParam.clusterAlternates
+                val chosen = all.random()
+                if (chosen == mediaParam.uri) mediaParam else mediaParam.copy(uri = chosen)
+            } else {
+                mediaParam
+            }
         ioScope.launch {
             val baseStream = ImagePlayerHelper.streamFromMedia(context, media)
             if (baseStream == null) {

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1151,6 +1151,38 @@
     <string name="immich_include_recent_default" translatable="false">DISABLED</string>
     <string name="immich_include_favorites_default" translatable="false">DISABLED</string>
 
+    <string-array name="immich_smart_slideshow_gap_entries" translatable="false">
+        <item>1 minute</item>
+        <item>10 minutes</item>
+        <item>30 minutes</item>
+        <item>1 hour</item>
+        <item>6 hours</item>
+        <item>1 day</item>
+    </string-array>
+    <string-array name="immich_smart_slideshow_gap_values" translatable="false">
+        <item>1</item>
+        <item>10</item>
+        <item>30</item>
+        <item>60</item>
+        <item>360</item>
+        <item>1440</item>
+    </string-array>
+
+    <string-array name="immich_smart_slideshow_exempt_percent_entries" translatable="false">
+        <item>100% (keep all)</item>
+        <item>75%</item>
+        <item>50%</item>
+        <item>25%</item>
+        <item>10%</item>
+    </string-array>
+    <string-array name="immich_smart_slideshow_exempt_percent_values" translatable="false">
+        <item>100</item>
+        <item>75</item>
+        <item>50</item>
+        <item>25</item>
+        <item>10</item>
+    </string-array>
+
     <string name="immich_img_preview">Preview</string>
     <string name="immich_img_fullsize">Fullsize</string>
     <string name="immich_img_original">Original</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -358,6 +358,16 @@
     <string name="immich_media_include_random_title">Include random photos</string>
     <string name="immich_media_include_recent_title">Include recent photos</string>
 
+    <string name="immich_smart_slideshow_title">Smart slideshow</string>
+    <string name="immich_smart_slideshow_summary">Collapse photos taken close in time into one slot so bursts and event photos don\'t dominate the mix</string>
+    <string name="immich_smart_slideshow_gap_title">Clustering window</string>
+    <string name="immich_smart_slideshow_gap_summary">Photos within this time window are treated as one moment (one random representative is shown)</string>
+    <string name="immich_smart_slideshow_exempt_title">Exempt album name pattern (regex)</string>
+    <string name="immich_smart_slideshow_exempt_summary">Albums whose names match this regex will bypass clustering (use for film scans etc. where timestamps lie)</string>
+    <string name="immich_smart_slideshow_exempt_percent_title">Keep exempt photos</string>
+    <string name="immich_smart_slideshow_exempt_percent_summary">How many of the exempt-album photos to keep in the playlist (random sample)</string>
+    <string name="category_immich_smart_slideshow">Smart slideshow</string>
+
     <string name="immich_media_test_summary1">Files found: %1$s</string>
     <string name="immich_media_test_summary2">Unsupported files: %1$s</string>
     <string name="immich_media_test_summary3">Videos found: %1$s</string>

--- a/app/src/main/res/xml/sources_immich_videos.xml
+++ b/app/src/main/res/xml/sources_immich_videos.xml
@@ -126,6 +126,46 @@
                     app:useSimpleSummaryProvider="true" />
         </PreferenceCategory>
 
+        <PreferenceCategory app:title="@string/category_immich_smart_slideshow">
+                <SwitchPreference
+                    app:dependency="immich_media_enabled"
+                    app:defaultValue="false"
+                    app:key="immich_smart_slideshow_enabled"
+                    app:title="@string/immich_smart_slideshow_title"
+                    app:summary="@string/immich_smart_slideshow_summary" />
+
+                <ListPreference
+                    app:dependency="immich_smart_slideshow_enabled"
+                    app:disableDependentsState="false"
+                    app:defaultValue="30"
+                    app:entries="@array/immich_smart_slideshow_gap_entries"
+                    app:entryValues="@array/immich_smart_slideshow_gap_values"
+                    app:key="immich_smart_slideshow_gap_minutes"
+                    app:title="@string/immich_smart_slideshow_gap_title"
+                    app:summary="@string/immich_smart_slideshow_gap_summary"
+                    app:useSimpleSummaryProvider="true" />
+
+                <EditTextPreference
+                    app:dependency="immich_smart_slideshow_enabled"
+                    app:disableDependentsState="false"
+                    app:defaultValue=""
+                    app:key="immich_smart_slideshow_exempt_pattern"
+                    app:title="@string/immich_smart_slideshow_exempt_title"
+                    app:summary="@string/immich_smart_slideshow_exempt_summary"
+                    android:selectAllOnFocus="true" />
+
+                <ListPreference
+                    app:dependency="immich_smart_slideshow_enabled"
+                    app:disableDependentsState="false"
+                    app:defaultValue="100"
+                    app:entries="@array/immich_smart_slideshow_exempt_percent_entries"
+                    app:entryValues="@array/immich_smart_slideshow_exempt_percent_values"
+                    app:key="immich_smart_slideshow_exempt_percent"
+                    app:title="@string/immich_smart_slideshow_exempt_percent_title"
+                    app:summary="@string/immich_smart_slideshow_exempt_percent_summary"
+                    app:useSimpleSummaryProvider="true" />
+        </PreferenceCategory>
+
         <PreferenceCategory app:title="@string/category_advanced">
                 <ListPreference
                     app:dependency="immich_media_enabled"


### PR DESCRIPTION
Hey, i'm not sure how useful / fitting this PR as is, and the settings that regulate this sort system may not be very intuitive for broader audience. Concept is mine, implementaion - entirely vibe coded, but it seems to work well for my case. Feel free to review it, or just reuse the concepts in future versions. 

## Summary

Adds an optional **Smart slideshow** mode for the Immich provider that evens out playback when you've selected a mix of single-day event albums and long-span collection albums.

The problem this solves: with the current flat random, a 1000-photo vacation album drowns out a 50-photo themed collection because randomization has no notion of "one event = one moment". Burst sequences (several shots seconds apart) further compound the issue by occupying consecutive slideshow slots with near-duplicate frames.

## What it does

Inside the Immich provider, before mapping assets to `AerialMedia`:

1. **Temporal clustering.** Sort by `localDateTime`, group consecutive assets when the gap is below a user-configurable threshold (default 30 min, options 1/10/30/60/360/1440). One random representative per cluster survives into the playlist. Clusters get re-randomized each fetch, so across sessions the user still sees the non-representative frames.
2. **Optional exempt regex.** Albums whose names match a user-supplied regex bypass clustering — useful for scanned film where `dateTimeOriginal` reflects the scan session, not the actual shoot time, and would collapse an entire roll into one slot. Default empty (opt-in).
3. **Exempt keep-percent.** Even with exempt, user can dampen exempt-album airtime via a random subsample (25/50/75/100%). Default 100%.

All three knobs live under a new "Smart slideshow" `PreferenceCategory` on the Immich source screen. Feature is **off by default** — existing playback behaviour is unchanged for anyone who doesn't opt in.

## Files

- `providers/immich/ImmichClusterer.kt` — the algorithm (pure, ~90 LOC, testable)
- `providers/immich/ImmichMediaProvider.kt` — call site, gates on new pref
- `models/prefs/ImmichMediaPrefs.kt` — three new prefs
- `res/xml/sources_immich_videos.xml` — new PreferenceCategory
- `res/values/arrays.xml` + `strings.xml` — UI strings and entries

## Test plan

- [ ] Leave the feature off → media count and playback identical to current master.
- [ ] Enable with gap=30 → verify large single-day albums are represented by ~N/density clusters, not by every frame.
- [ ] Enable with exempt regex matching a known burst-sensitive album → that album's assets bypass collapse; non-matching albums still collapse normally.
- [ ] Exempt keep-percent = 50 → roughly half of exempt assets drop out (random).
- [ ] Verify no crash when an asset lacks `localDateTime` (falls through to a separate un-dated bucket, returned verbatim).
- [ ] Fetch → force refresh → representatives differ across runs (re-randomization works).

## Notes

Scope kept intentionally narrow to the Immich pipeline. The clusterer is a pure function and safe to ignore for other providers. A follow-up PR will add DATE_TIME_TAKEN and SOURCE_POOL overlay tags + optional periodic playlist refresh (see #TBD).