### PR TITLE
Portrait handling improvements

### DIFF
--- a/app/src/main/java/com/neilturner/aerialviews/models/enums/PhotoScale.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/models/enums/PhotoScale.kt
@@ -3,4 +3,5 @@ package com.neilturner.aerialviews.models.enums
 enum class PhotoScale {
     CENTER_CROP,
     FIT_CENTER,
+    KEN_BURNS_VERTICAL,
 }

--- a/app/src/main/java/com/neilturner/aerialviews/models/prefs/GeneralPrefs.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/models/prefs/GeneralPrefs.kt
@@ -237,6 +237,8 @@ object GeneralPrefs : KotprefModel() {
     var slideshowSpeed by stringPref("30", "slideshow_speed")
     var photoScalePortrait by nullableEnumValuePref(PhotoScale.CENTER_CROP, "photo_scale_portrait")
     var photoScaleLandscape by nullableEnumValuePref(PhotoScale.CENTER_CROP, "photo_scale_landscape")
+    var photoScaleFaceAware by booleanPref(false, "photo_scale_face_aware")
+    var photoScaleFaceOffScreenPercent by stringPref("0", "photo_scale_face_off_screen_percent")
     var photoBackgroundBlurEnabled by booleanPref(true, "photo_background_blur_enabled")
     var photoBackgroundBlurOpacity by stringPref("40", "photo_background_blur_opacity")
     var photoBackgroundBlurIntensity by stringPref("80", "photo_background_blur_intensity")

--- a/app/src/main/java/com/neilturner/aerialviews/models/prefs/ImmichMediaPrefs.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/models/prefs/ImmichMediaPrefs.kt
@@ -45,4 +45,8 @@ object ImmichMediaPrefs : KotprefModel(), ImmichUrlPrefs, ImmichAssetPrefs {
     var includeRecent by stringPref("DISABLED", "immich_media_include_recent")
     override var imageType by nullableEnumValuePref(ImmichImageType.PREVIEW, "immich_media_image_type")
     override var videoType by nullableEnumValuePref(ImmichVideoType.TRANSCODED, "immich_media_video_type")
+    var smartSlideshowEnabled by booleanPref(false, "immich_smart_slideshow_enabled")
+    var smartSlideshowGapMinutes by stringPref("30", "immich_smart_slideshow_gap_minutes")
+    var smartSlideshowExemptAlbumPattern by stringPref("", "immich_smart_slideshow_exempt_pattern")
+    var smartSlideshowExemptPercent by stringPref("100", "immich_smart_slideshow_exempt_percent")
 }

--- a/app/src/main/java/com/neilturner/aerialviews/models/videos/AerialMedia.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/models/videos/AerialMedia.kt
@@ -11,11 +11,16 @@ data class AerialMedia(
     var type: AerialMediaType = AerialMediaType.VIDEO,
     var source: AerialMediaSource = AerialMediaSource.UNKNOWN,
     var metadata: AerialMediaMetadata = AerialMediaMetadata(),
-    // Alternate URIs that belong to the same logical slot (e.g. other members of a
-    // temporal cluster from the Immich smart slideshow). When non-empty, the renderer
-    // picks one at random — including `uri` itself — every time the slot is shown,
-    // so across playlist loops the user sees variety within the cluster.
-    var clusterAlternates: List<Uri> = emptyList(),
+    // Other members of the same logical slot (e.g. temporal-cluster siblings from the
+    // Immich smart slideshow). Each carries its own URI plus — when face-aware crop is
+    // enabled — its own per-photo subject rectangle, so the renderer can randomize
+    // across cluster members without inheriting a mis-aligned face bbox from the primary.
+    var clusterAlternates: List<ClusterAlternate> = emptyList(),
+)
+
+data class ClusterAlternate(
+    val uri: Uri,
+    val subjectRect: NormalizedRect? = null,
 )
 
 data class AerialMediaMetadata(
@@ -26,7 +31,22 @@ data class AerialMediaMetadata(
     var exif: AerialExifMetadata = AerialExifMetadata(),
     var albumName: String = "",
     var title: String = "",
+    // Normalized (0..1 of image width/height) rect around a primary subject in the photo,
+    // used by portrait crop/pan logic to keep the subject on-screen.
+    var subjectRect: NormalizedRect? = null,
 )
+
+/** Rectangle in normalized image coordinates where each field is 0..1 of image width/height. */
+data class NormalizedRect(
+    val left: Float,
+    val top: Float,
+    val right: Float,
+    val bottom: Float,
+) {
+    val centerY: Float get() = (top + bottom) / 2f
+    val height: Float get() = bottom - top
+    val area: Float get() = (right - left) * (bottom - top)
+}
 
 data class AerialExifMetadata(
     var date: String? = null,

--- a/app/src/main/java/com/neilturner/aerialviews/models/videos/AerialMedia.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/models/videos/AerialMedia.kt
@@ -11,6 +11,11 @@ data class AerialMedia(
     var type: AerialMediaType = AerialMediaType.VIDEO,
     var source: AerialMediaSource = AerialMediaSource.UNKNOWN,
     var metadata: AerialMediaMetadata = AerialMediaMetadata(),
+    // Alternate URIs that belong to the same logical slot (e.g. other members of a
+    // temporal cluster from the Immich smart slideshow). When non-empty, the renderer
+    // picks one at random — including `uri` itself — every time the slot is shown,
+    // so across playlist loops the user sees variety within the cluster.
+    var clusterAlternates: List<Uri> = emptyList(),
 )
 
 data class AerialMediaMetadata(

--- a/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichApi.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichApi.kt
@@ -53,6 +53,12 @@ interface ImmichApi {
         @Header("x-api-key") apiKey: String,
         @Body searchRequest: SearchMetadataRequest,
     ): Response<SearchAssetsResponse>
+
+    @GET("/api/assets/{id}")
+    suspend fun getAssetDetail(
+        @Header("x-api-key") apiKey: String,
+        @Path("id") assetId: String,
+    ): Response<Asset>
 }
 
 @Serializable
@@ -92,6 +98,34 @@ data class Asset(
     val description: String? = null,
     val exifInfo: ExifInfo? = null,
     val albumName: String? = null,
+    // Pixel dimensions of the asset as stored by Immich (post-orientation). Present on
+    // album/search responses, useful for deciding whether an asset is a portrait before
+    // any per-asset detail fetch.
+    val width: Int? = null,
+    val height: Int? = null,
+    // Populated only by GET /api/assets/{id}; list endpoints return an empty array
+    // in Immich 2.7.5 even when withPeople/withFaces is requested.
+    val people: List<ImmichPerson>? = null,
+)
+
+@Serializable
+data class ImmichPerson(
+    val id: String = "",
+    val name: String = "",
+    val faces: List<ImmichFace> = emptyList(),
+)
+
+@Serializable
+data class ImmichFace(
+    val id: String = "",
+    val boundingBoxX1: Int = 0,
+    val boundingBoxY1: Int = 0,
+    val boundingBoxX2: Int = 0,
+    val boundingBoxY2: Int = 0,
+    // Frame the face detection ran on — usually smaller than the original asset.
+    // Normalize bbox against these (NOT against asset.width/height).
+    val imageWidth: Int = 0,
+    val imageHeight: Int = 0,
 )
 
 @Serializable

--- a/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichAssetMapper.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichAssetMapper.kt
@@ -6,6 +6,8 @@ import com.neilturner.aerialviews.models.prefs.ImmichAssetPrefs
 import com.neilturner.aerialviews.models.videos.AerialExifMetadata
 import com.neilturner.aerialviews.models.videos.AerialMedia
 import com.neilturner.aerialviews.models.videos.AerialMediaMetadata
+import com.neilturner.aerialviews.models.videos.ClusterAlternate
+import com.neilturner.aerialviews.models.videos.NormalizedRect
 import com.neilturner.aerialviews.utils.FileHelper
 import timber.log.Timber
 
@@ -33,6 +35,7 @@ class ImmichAssetMapper(
     fun processAssets(
         assets: List<Asset>,
         alternatesByPrimaryId: Map<String, List<Asset>> = emptyMap(),
+        faceRectByAssetId: Map<String, NormalizedRect> = emptyMap(),
     ): ProcessResults {
         val media = mutableListOf<AerialMedia>()
         var excluded = 0
@@ -59,11 +62,17 @@ class ImmichAssetMapper(
 
                 val exif = extractExifMetadata(asset)
                 val uri = urlBuilder.getAssetUri(asset.id, isVideo)
-                val altUris =
+                val face = faceRectByAssetId[asset.id]
+                val altEntries =
                     alternatesByPrimaryId[asset.id]
                         ?.filter { FileHelper.isSupportedImageType(it.originalPath) == isImage &&
                                    FileHelper.isSupportedVideoType(it.originalPath) == isVideo }
-                        ?.map { urlBuilder.getAssetUri(it.id, isVideo) }
+                        ?.map { altAsset ->
+                            ClusterAlternate(
+                                uri = urlBuilder.getAssetUri(altAsset.id, isVideo),
+                                subjectRect = faceRectByAssetId[altAsset.id],
+                            )
+                        }
                         .orEmpty()
                 val item =
                     AerialMedia(
@@ -72,8 +81,9 @@ class ImmichAssetMapper(
                             AerialMediaMetadata(
                                 albumName = asset.albumName.orEmpty(),
                                 exif = exif,
+                                subjectRect = face,
                             ),
-                        clusterAlternates = altUris,
+                        clusterAlternates = altEntries,
                     ).apply {
                         source = AerialMediaSource.IMMICH
                         type = if (isVideo) AerialMediaType.VIDEO else AerialMediaType.IMAGE

--- a/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichAssetMapper.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichAssetMapper.kt
@@ -30,7 +30,10 @@ class ImmichAssetMapper(
             }
         }
 
-    fun processAssets(assets: List<Asset>): ProcessResults {
+    fun processAssets(
+        assets: List<Asset>,
+        alternatesByPrimaryId: Map<String, List<Asset>> = emptyMap(),
+    ): ProcessResults {
         val media = mutableListOf<AerialMedia>()
         var excluded = 0
         var videos = 0
@@ -56,6 +59,12 @@ class ImmichAssetMapper(
 
                 val exif = extractExifMetadata(asset)
                 val uri = urlBuilder.getAssetUri(asset.id, isVideo)
+                val altUris =
+                    alternatesByPrimaryId[asset.id]
+                        ?.filter { FileHelper.isSupportedImageType(it.originalPath) == isImage &&
+                                   FileHelper.isSupportedVideoType(it.originalPath) == isVideo }
+                        ?.map { urlBuilder.getAssetUri(it.id, isVideo) }
+                        .orEmpty()
                 val item =
                     AerialMedia(
                         uri,
@@ -64,6 +73,7 @@ class ImmichAssetMapper(
                                 albumName = asset.albumName.orEmpty(),
                                 exif = exif,
                             ),
+                        clusterAlternates = altUris,
                     ).apply {
                         source = AerialMediaSource.IMMICH
                         type = if (isVideo) AerialMediaType.VIDEO else AerialMediaType.IMAGE

--- a/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichClusterer.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichClusterer.kt
@@ -1,0 +1,89 @@
+package com.neilturner.aerialviews.providers.immich
+
+import timber.log.Timber
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+
+object ImmichClusterer {
+    private val parsers =
+        listOf(
+            DateTimeFormatter.ISO_LOCAL_DATE_TIME,
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS"),
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"),
+        )
+
+    fun cluster(
+        assets: List<Asset>,
+        gapMinutes: Int,
+        exemptPattern: Regex? = null,
+        exemptKeepFraction: Double = 1.0,
+    ): List<Asset> {
+        if (assets.isEmpty() || gapMinutes <= 0) return assets
+
+        val exemptAll = mutableListOf<Asset>()
+        val dated = mutableListOf<Pair<Asset, Long>>()
+        val undated = mutableListOf<Asset>()
+
+        for (asset in assets) {
+            if (exemptPattern != null && exemptPattern.containsMatchIn(asset.albumName.orEmpty())) {
+                exemptAll += asset
+                continue
+            }
+            val epoch = asset.localDateTime?.let(::parseEpochSeconds)
+            if (epoch != null) dated += asset to epoch else undated += asset
+        }
+
+        val exemptKept =
+            when {
+                exemptKeepFraction >= 1.0 -> exemptAll
+                exemptKeepFraction <= 0.0 -> emptyList()
+                else -> {
+                    val n = (exemptAll.size * exemptKeepFraction).toInt()
+                    if (n >= exemptAll.size) exemptAll else exemptAll.shuffled().take(n)
+                }
+            }
+
+        dated.sortBy { it.second }
+
+        val gapSeconds = gapMinutes.toLong() * 60
+        val representatives = mutableListOf<Asset>()
+        var clusterStart = 0
+        for (i in 1..dated.size) {
+            val breakHere = i == dated.size || (dated[i].second - dated[i - 1].second) > gapSeconds
+            if (breakHere) {
+                val cluster = dated.subList(clusterStart, i)
+                representatives += cluster.random().first
+                clusterStart = i
+            }
+        }
+
+        representatives += undated
+        representatives += exemptKept
+
+        Timber.i(
+            "ImmichClusterer: %d in → %d clusters + %d undated + %d/%d exempt (gap=%d min, keep=%.2f)",
+            assets.size,
+            representatives.size - undated.size - exemptKept.size,
+            undated.size,
+            exemptKept.size,
+            exemptAll.size,
+            gapMinutes,
+            exemptKeepFraction,
+        )
+
+        return representatives
+    }
+
+    private fun parseEpochSeconds(raw: String): Long? {
+        val normalized = raw.trim().replace(Regex("(?i)(?:z|[+-]\\d{2}:?\\d{2})$"), "")
+        for (parser in parsers) {
+            try {
+                return LocalDateTime.parse(normalized, parser).toEpochSecond(java.time.ZoneOffset.UTC)
+            } catch (_: DateTimeParseException) {
+            }
+        }
+        Timber.w("ImmichClusterer: failed to parse localDateTime '%s'", raw)
+        return null
+    }
+}

--- a/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichClusterer.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichClusterer.kt
@@ -13,13 +13,24 @@ object ImmichClusterer {
             DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"),
         )
 
+    data class Result(
+        val representatives: List<Asset>,
+        /**
+         * Per-cluster alternate members, keyed by representative asset id.
+         * Callers can use this to present variety across playlist loops —
+         * pick a random alternate each time the slot is rendered instead of
+         * freezing the choice at fetch time.
+         */
+        val alternatesByPrimaryId: Map<String, List<Asset>> = emptyMap(),
+    )
+
     fun cluster(
         assets: List<Asset>,
         gapMinutes: Int,
         exemptPattern: Regex? = null,
         exemptKeepFraction: Double = 1.0,
-    ): List<Asset> {
-        if (assets.isEmpty() || gapMinutes <= 0) return assets
+    ): Result {
+        if (assets.isEmpty() || gapMinutes <= 0) return Result(assets)
 
         val exemptAll = mutableListOf<Asset>()
         val dated = mutableListOf<Pair<Asset, Long>>()
@@ -48,12 +59,17 @@ object ImmichClusterer {
 
         val gapSeconds = gapMinutes.toLong() * 60
         val representatives = mutableListOf<Asset>()
+        val alternates = mutableMapOf<String, List<Asset>>()
         var clusterStart = 0
         for (i in 1..dated.size) {
             val breakHere = i == dated.size || (dated[i].second - dated[i - 1].second) > gapSeconds
             if (breakHere) {
-                val cluster = dated.subList(clusterStart, i)
-                representatives += cluster.random().first
+                val clusterAssets = dated.subList(clusterStart, i).map { it.first }
+                val rep = clusterAssets.random()
+                representatives += rep
+                if (clusterAssets.size > 1) {
+                    alternates[rep.id] = clusterAssets.filter { it.id != rep.id }
+                }
                 clusterStart = i
             }
         }
@@ -62,9 +78,10 @@ object ImmichClusterer {
         representatives += exemptKept
 
         Timber.i(
-            "ImmichClusterer: %d in → %d clusters + %d undated + %d/%d exempt (gap=%d min, keep=%.2f)",
+            "ImmichClusterer: %d in → %d clusters (with %d alternates-carrying) + %d undated + %d/%d exempt (gap=%d min, keep=%.2f)",
             assets.size,
             representatives.size - undated.size - exemptKept.size,
+            alternates.size,
             undated.size,
             exemptKept.size,
             exemptAll.size,
@@ -72,7 +89,7 @@ object ImmichClusterer {
             exemptKeepFraction,
         )
 
-        return representatives
+        return Result(representatives, alternates)
     }
 
     private fun parseEpochSeconds(raw: String): Long? {

--- a/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichMediaProvider.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichMediaProvider.kt
@@ -90,7 +90,7 @@ class ImmichMediaProvider(
             return Pair(media, "No files found")
         }
 
-        val assetsForMapping =
+        val clusterResult =
             if (prefs.smartSlideshowEnabled) {
                 val gap = prefs.smartSlideshowGapMinutes.toIntOrNull() ?: 30
                 val exemptPattern =
@@ -107,11 +107,15 @@ class ImmichMediaProvider(
                 val exemptKeep = (prefs.smartSlideshowExemptPercent.toIntOrNull() ?: 100).coerceIn(0, 100) / 100.0
                 ImmichClusterer.cluster(assetResults.allAssets, gap, exemptPattern, exemptKeep)
             } else {
-                assetResults.allAssets
+                ImmichClusterer.Result(assetResults.allAssets)
             }
 
         // Process assets and create media list
-        val processResults = mapper.processAssets(assetsForMapping)
+        val processResults =
+            mapper.processAssets(
+                clusterResult.representatives,
+                clusterResult.alternatesByPrimaryId,
+            )
         media.addAll(processResults.media)
 
         // Build summary message

--- a/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichMediaProvider.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichMediaProvider.kt
@@ -90,8 +90,28 @@ class ImmichMediaProvider(
             return Pair(media, "No files found")
         }
 
+        val assetsForMapping =
+            if (prefs.smartSlideshowEnabled) {
+                val gap = prefs.smartSlideshowGapMinutes.toIntOrNull() ?: 30
+                val exemptPattern =
+                    prefs.smartSlideshowExemptAlbumPattern
+                        .takeIf { it.isNotBlank() }
+                        ?.let {
+                            try {
+                                Regex(it)
+                            } catch (e: Exception) {
+                                Timber.w(e, "Invalid exempt album pattern: '%s'", it)
+                                null
+                            }
+                        }
+                val exemptKeep = (prefs.smartSlideshowExemptPercent.toIntOrNull() ?: 100).coerceIn(0, 100) / 100.0
+                ImmichClusterer.cluster(assetResults.allAssets, gap, exemptPattern, exemptKeep)
+            } else {
+                assetResults.allAssets
+            }
+
         // Process assets and create media list
-        val processResults = mapper.processAssets(assetResults.allAssets)
+        val processResults = mapper.processAssets(assetsForMapping)
         media.addAll(processResults.media)
 
         // Build summary message

--- a/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichMediaProvider.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichMediaProvider.kt
@@ -110,11 +110,34 @@ class ImmichMediaProvider(
                 ImmichClusterer.Result(assetResults.allAssets)
             }
 
+        // Optionally enrich ALL portrait assets (not just cluster representatives) with
+        // face bounding boxes so the renderer can bias center-crop / Ken Burns pan toward
+        // the subject — for whichever cluster member is randomly chosen at render time,
+        // not just the designated primary.
+        val faceRectByAssetId =
+            if (com.neilturner.aerialviews.models.prefs.GeneralPrefs.photoScaleFaceAware) {
+                val portraits =
+                    assetResults.allAssets.filter { a ->
+                        val w = a.width ?: 0
+                        val h = a.height ?: 0
+                        w > 0 && h > w
+                    }
+                try {
+                    repository.enrichPortraitsWithFaces(portraits)
+                } catch (e: Exception) {
+                    Timber.w(e, "Immich face enrichment failed; continuing without")
+                    emptyMap()
+                }
+            } else {
+                emptyMap()
+            }
+
         // Process assets and create media list
         val processResults =
             mapper.processAssets(
                 clusterResult.representatives,
                 clusterResult.alternatesByPrimaryId,
+                faceRectByAssetId,
             )
         media.addAll(processResults.media)
 

--- a/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichRepository.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/providers/immich/ImmichRepository.kt
@@ -381,6 +381,54 @@ class ImmichRepository(
         }
     }
 
+    /**
+     * For each portrait-aspect asset (height > width according to the supplied hint),
+     * fetch `/api/assets/{id}` in parallel and extract the largest detected face
+     * bounding box, normalized to 0..1 against the ML-preview frame that Immich used
+     * for detection (asset_face.imageWidth/imageHeight — NOT asset.width/height).
+     *
+     * Returns a map from asset id to normalized (left, top, right, bottom). Assets
+     * with no detected face, or where the fetch fails, are simply absent from the map.
+     * Never throws — failure to fetch any given asset is logged and skipped.
+     */
+    suspend fun enrichPortraitsWithFaces(
+        assetsNeedingFaces: List<Asset>,
+    ): Map<String, com.neilturner.aerialviews.models.videos.NormalizedRect> =
+        coroutineScope {
+            if (assetsNeedingFaces.isEmpty()) return@coroutineScope emptyMap()
+
+            val deferreds =
+                assetsNeedingFaces.map { a ->
+                    async {
+                        try {
+                            val resp = immichClient.getAssetDetail(prefs.apiKey, a.id)
+                            if (!resp.isSuccessful) return@async null
+                            val detail = resp.body() ?: return@async null
+                            val faces = detail.people.orEmpty().flatMap { it.faces }
+                            val largest =
+                                faces
+                                    .filter { it.imageWidth > 0 && it.imageHeight > 0 }
+                                    .maxByOrNull { (it.boundingBoxX2 - it.boundingBoxX1).toLong() *
+                                                   (it.boundingBoxY2 - it.boundingBoxY1).toLong() }
+                                    ?: return@async null
+                            a.id to com.neilturner.aerialviews.models.videos.NormalizedRect(
+                                left = largest.boundingBoxX1.toFloat() / largest.imageWidth.toFloat(),
+                                top = largest.boundingBoxY1.toFloat() / largest.imageHeight.toFloat(),
+                                right = largest.boundingBoxX2.toFloat() / largest.imageWidth.toFloat(),
+                                bottom = largest.boundingBoxY2.toFloat() / largest.imageHeight.toFloat(),
+                            )
+                        } catch (e: Exception) {
+                            Timber.d(e, "face-enrichment: failed for asset ${a.id}")
+                            null
+                        }
+                    }
+                }
+
+            val resolved = deferreds.awaitAll().filterNotNull().toMap()
+            Timber.i("Immich face enrichment: %d / %d portrait assets have a detected face", resolved.size, assetsNeedingFaces.size)
+            resolved
+        }
+
     suspend fun fetchAlbums(): Result<List<Album>> =
         coroutineScope {
             try {

--- a/app/src/main/java/com/neilturner/aerialviews/ui/core/ImagePlayerView.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/ui/core/ImagePlayerView.kt
@@ -2,8 +2,10 @@ package com.neilturner.aerialviews.ui.core
 
 import android.animation.ValueAnimator
 import android.content.Context
+import android.graphics.Bitmap
 import android.graphics.Matrix
 import android.graphics.drawable.Animatable
+import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import android.view.animation.LinearInterpolator
@@ -30,6 +32,7 @@ import com.neilturner.aerialviews.ui.overlays.ProgressBarEvent
 import com.neilturner.aerialviews.ui.overlays.ProgressState
 import com.neilturner.aerialviews.utils.BitmapHelper
 import com.neilturner.aerialviews.utils.FirebaseHelper
+import com.neilturner.aerialviews.utils.SplashCache
 import com.neilturner.aerialviews.utils.ToastHelper
 import com.neilturner.aerialviews.utils.filename
 import kotlinx.coroutines.CoroutineScope
@@ -63,6 +66,8 @@ class ImagePlayerView : FrameLayout {
 
     private var kenBurnsAnimator: ValueAnimator? = null
     private var pendingKenBurns: KenBurnsSetup? = null
+
+    private var splashSaveCountdown: Int = SPLASH_SAVE_EVERY_N_SLOTS
 
     /**
      * Precomputed state for one vertical pan. Start/end translate-Y are the matrix
@@ -335,6 +340,9 @@ class ImagePlayerView : FrameLayout {
 
     companion object {
         private const val STREAM_BUFFER_SIZE = 64 * 1024 // 64KB - helps reduce network round-trips
+        // How often (in displayed photos) to save a loading-splash snapshot.
+        // ~50 slots at slideshow_speed=25s ≈ one write per 20 min — gentle on flash.
+        private const val SPLASH_SAVE_EVERY_N_SLOTS = 50
     }
 
     private fun resolveTargetSize(): Pair<Int, Int> {
@@ -602,6 +610,33 @@ class ImagePlayerView : FrameLayout {
         if (progressBar) GlobalBus.post(ProgressBarEvent(ProgressState.START, 0, duration))
         startKenBurnsIfPending(duration)
         postDelayed(finishedRunnable, durationMinusFade)
+        maybeSaveSplashSnapshot()
+    }
+
+    /**
+     * Periodically persist the currently-shown bitmap as the next-launch splash so the
+     * loading screen shows something meaningful instead of a black rectangle. Runs at
+     * most once every [SPLASH_SAVE_EVERY_N_SLOTS] rendered photos, and is a best-effort
+     * IO-scope job — failures are swallowed so playback is never affected.
+     */
+    private fun maybeSaveSplashSnapshot() {
+        if (--splashSaveCountdown > 0) return
+        splashSaveCountdown = SPLASH_SAVE_EVERY_N_SLOTS
+        val bmp = (foregroundImageView.drawable as? BitmapDrawable)?.bitmap ?: return
+        if (bmp.isRecycled) return
+        val appContext = context.applicationContext
+        ioScope.launch { SplashCache.save(appContext, bmp) }
+    }
+
+    /**
+     * Set the given bitmap as the foreground image without starting any timer or
+     * triggering playback callbacks. Used by the screensaver init to paint the
+     * previously-cached snapshot behind the loading UI instead of a black screen.
+     * The next real image load replaces this bitmap on arrival.
+     */
+    fun showSplashBitmap(bitmap: Bitmap) {
+        foregroundImageView.scaleType = ImageView.ScaleType.CENTER_CROP
+        setForegroundDrawable(BitmapDrawable(resources, bitmap))
     }
 
     private fun markBackgroundReady(token: Long) {

--- a/app/src/main/java/com/neilturner/aerialviews/ui/core/ImagePlayerView.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/ui/core/ImagePlayerView.kt
@@ -1,9 +1,12 @@
 package com.neilturner.aerialviews.ui.core
 
+import android.animation.ValueAnimator
 import android.content.Context
+import android.graphics.Matrix
 import android.graphics.drawable.Animatable
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
+import android.view.animation.LinearInterpolator
 import android.widget.FrameLayout
 import android.widget.ImageView
 import androidx.appcompat.widget.AppCompatImageView
@@ -57,6 +60,11 @@ class ImagePlayerView : FrameLayout {
     private var pausedTimestamp: Long = 0
     private var totalDuration: Long = 0
     private var remainingDuration: Long = 0
+
+    private var kenBurnsAnimator: ValueAnimator? = null
+    private var pendingKenBurns: KenBurnsSetup? = null
+
+    private data class KenBurnsSetup(val scale: Float, val overflow: Float)
 
     /**
      * Two-token sync gate: ensures [runSetupFinishedRunnable] fires only after *both*
@@ -332,6 +340,9 @@ class ImagePlayerView : FrameLayout {
 
     fun stop() {
         removeCallbacks(finishedRunnable)
+        kenBurnsAnimator?.cancel()
+        kenBurnsAnimator = null
+        pendingKenBurns = null
         setForegroundDrawable(null)
         pausedTimestamp = 0
         remainingDuration = 0
@@ -341,6 +352,7 @@ class ImagePlayerView : FrameLayout {
     fun pauseTimer() {
         pausedTimestamp = System.currentTimeMillis()
         removeCallbacks(finishedRunnable)
+        kenBurnsAnimator?.takeIf { it.isRunning }?.pause()
     }
 
     fun resumeTimer(pauseDuration: Long) {
@@ -348,6 +360,7 @@ class ImagePlayerView : FrameLayout {
             remainingDuration = maxOf(0, remainingDuration - pauseDuration)
             if (remainingDuration > 0) {
                 postDelayed(finishedRunnable, remainingDuration)
+                kenBurnsAnimator?.takeIf { it.isPaused }?.resume()
             } else {
                 // If time has expired, finish immediately
                 listener?.onImageFinished()
@@ -360,6 +373,26 @@ class ImagePlayerView : FrameLayout {
         width: Int,
         height: Int,
     ) {
+        kenBurnsAnimator?.cancel()
+        pendingKenBurns = null
+
+        val aspect = AspectRatio.fromDimensions(width, height)
+        Timber.i("Aspect ratio: $aspect")
+        val pref =
+            when (aspect) {
+                AspectRatio.SQUARE, AspectRatio.PORTRAIT -> GeneralPrefs.photoScalePortrait
+                AspectRatio.LANDSCAPE -> GeneralPrefs.photoScaleLandscape
+            }
+
+        if (pref == PhotoScale.KEN_BURNS_VERTICAL) {
+            val setup = prepareVerticalPan(width, height)
+            if (setup != null) {
+                foregroundImageView.scaleType = ImageView.ScaleType.MATRIX
+                applyVerticalPanMatrix(setup, 0f)
+                pendingKenBurns = setup
+                return
+            }
+        }
         foregroundImageView.scaleType = resolveForegroundScaleType(width, height)
     }
 
@@ -368,7 +401,6 @@ class ImagePlayerView : FrameLayout {
         height: Int,
     ): ImageView.ScaleType {
         val aspect = AspectRatio.fromDimensions(width, height)
-        Timber.i("Aspect ratio: $aspect")
         return when (aspect) {
             AspectRatio.SQUARE, AspectRatio.PORTRAIT -> getScaleType(GeneralPrefs.photoScalePortrait)
             AspectRatio.LANDSCAPE -> getScaleType(GeneralPrefs.photoScaleLandscape)
@@ -376,12 +408,58 @@ class ImagePlayerView : FrameLayout {
     }
 
     private fun getScaleType(scale: PhotoScale?): ImageView.ScaleType =
-        try {
-            ImageView.ScaleType.valueOf(scale.toString())
-        } catch (e: Exception) {
-            Timber.e(e)
-            ImageView.ScaleType.valueOf(PhotoScale.CENTER_CROP.toString())
+        when (scale) {
+            PhotoScale.CENTER_CROP -> ImageView.ScaleType.CENTER_CROP
+            PhotoScale.FIT_CENTER -> ImageView.ScaleType.FIT_CENTER
+            // KEN_BURNS_VERTICAL on images that don't qualify (landscape, square, or container
+            // not yet measured) falls back to center-crop so playback never breaks.
+            PhotoScale.KEN_BURNS_VERTICAL, null -> ImageView.ScaleType.CENTER_CROP
         }
+
+    /**
+     * Compute the matrix scale factor and vertical overflow needed to pan a taller-than-container
+     * image vertically with the image-width matching the container width. Returns null when the
+     * container isn't measured yet or the image doesn't actually overflow vertically.
+     */
+    private fun prepareVerticalPan(
+        imageWidth: Int,
+        imageHeight: Int,
+    ): KenBurnsSetup? {
+        val view = foregroundImageView
+        val containerW = view.width
+        val containerH = view.height
+        if (containerW <= 0 || containerH <= 0 || imageWidth <= 0 || imageHeight <= 0) return null
+        val scale = containerW.toFloat() / imageWidth.toFloat()
+        val overflow = imageHeight.toFloat() * scale - containerH.toFloat()
+        if (overflow <= 0f) return null
+        return KenBurnsSetup(scale = scale, overflow = overflow)
+    }
+
+    private fun applyVerticalPanMatrix(
+        setup: KenBurnsSetup,
+        translateY: Float,
+    ) {
+        val m = Matrix()
+        m.setScale(setup.scale, setup.scale)
+        m.postTranslate(0f, translateY)
+        foregroundImageView.imageMatrix = m
+    }
+
+    private fun startKenBurnsIfPending(durationMs: Long) {
+        val setup = pendingKenBurns ?: return
+        if (durationMs <= 0) return
+        // Alternate start direction per slot for visual variety.
+        val downward = (System.currentTimeMillis() / 1000L) % 2L == 0L
+        val startY = if (downward) 0f else -setup.overflow
+        val endY = if (downward) -setup.overflow else 0f
+        kenBurnsAnimator =
+            ValueAnimator.ofFloat(startY, endY).apply {
+                duration = durationMs
+                interpolator = LinearInterpolator()
+                addUpdateListener { applyVerticalPanMatrix(setup, it.animatedValue as Float) }
+                start()
+            }
+    }
 
     private fun setupFinishedRunnable() {
         removeCallbacks(finishedRunnable)
@@ -405,6 +483,7 @@ class ImagePlayerView : FrameLayout {
 
         Timber.i("Delay: ${durationMinusFade.milliseconds}")
         if (progressBar) GlobalBus.post(ProgressBarEvent(ProgressState.START, 0, duration))
+        startKenBurnsIfPending(duration)
         postDelayed(finishedRunnable, durationMinusFade)
     }
 

--- a/app/src/main/java/com/neilturner/aerialviews/ui/core/ImagePlayerView.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/ui/core/ImagePlayerView.kt
@@ -64,7 +64,17 @@ class ImagePlayerView : FrameLayout {
     private var kenBurnsAnimator: ValueAnimator? = null
     private var pendingKenBurns: KenBurnsSetup? = null
 
-    private data class KenBurnsSetup(val scale: Float, val overflow: Float)
+    /**
+     * Precomputed state for one vertical pan. Start/end translate-Y are the matrix
+     * translation values at the beginning and end of the animation respectively
+     * (0 = image top at container top, negative = image scrolled up / pan shows lower part).
+     */
+    private data class KenBurnsSetup(
+        val scale: Float,
+        val overflow: Float,
+        val startTranslateY: Float,
+        val endTranslateY: Float,
+    )
 
     /**
      * Two-token sync gate: ensures [runSetupFinishedRunnable] fires only after *both*
@@ -131,11 +141,20 @@ class ImagePlayerView : FrameLayout {
         // If this logical slot carries alternates (e.g. other members of a temporal
         // cluster from the Immich smart slideshow), pick one at random every time
         // the slot is rendered so the user sees variety across playlist loops.
+        // Each alternate carries its own per-photo subjectRect — cluster gap can span
+        // a full day, so inheriting the primary's face bbox would be geometrically wrong.
         val media =
             if (mediaParam.clusterAlternates.isNotEmpty()) {
-                val all = listOf(mediaParam.uri) + mediaParam.clusterAlternates
-                val chosen = all.random()
-                if (chosen == mediaParam.uri) mediaParam else mediaParam.copy(uri = chosen)
+                val pick = (0..mediaParam.clusterAlternates.size).random()
+                if (pick == 0) {
+                    mediaParam
+                } else {
+                    val alt = mediaParam.clusterAlternates[pick - 1]
+                    mediaParam.copy(
+                        uri = alt.uri,
+                        metadata = mediaParam.metadata.copy(subjectRect = alt.subjectRect),
+                    )
+                }
             } else {
                 mediaParam
             }
@@ -222,7 +241,7 @@ class ImagePlayerView : FrameLayout {
                         },
                     ).listener(
                         onSuccess = { _, result ->
-                            setScaleMode(result.image.width, result.image.height)
+                            setScaleMode(result.image.width, result.image.height, media.metadata.subjectRect)
                             setupFinishedRunnable()
                         },
                         onError = { _, result ->
@@ -372,27 +391,39 @@ class ImagePlayerView : FrameLayout {
     private fun setScaleMode(
         width: Int,
         height: Int,
+        subjectRect: com.neilturner.aerialviews.models.videos.NormalizedRect? = null,
     ) {
         kenBurnsAnimator?.cancel()
         pendingKenBurns = null
 
         val aspect = AspectRatio.fromDimensions(width, height)
-        Timber.i("Aspect ratio: $aspect")
         val pref =
             when (aspect) {
                 AspectRatio.SQUARE, AspectRatio.PORTRAIT -> GeneralPrefs.photoScalePortrait
                 AspectRatio.LANDSCAPE -> GeneralPrefs.photoScaleLandscape
             }
 
+        // Face-aware logic only applies to true portraits (h > w) so landscape/square
+        // behavior stays exactly as it was.
+        val faceRect =
+            if (aspect == AspectRatio.PORTRAIT && GeneralPrefs.photoScaleFaceAware) subjectRect else null
+        Timber.i("Aspect ratio: $aspect")
+
         if (pref == PhotoScale.KEN_BURNS_VERTICAL) {
-            val setup = prepareVerticalPan(width, height)
+            val setup = prepareVerticalPan(width, height, faceRect)
             if (setup != null) {
                 foregroundImageView.scaleType = ImageView.ScaleType.MATRIX
-                applyVerticalPanMatrix(setup, 0f)
+                applyVerticalPanMatrix(setup, setup.startTranslateY)
                 pendingKenBurns = setup
                 return
             }
         }
+
+        // Static face-biased center-crop (rule-of-thirds) for portraits when face-aware is on.
+        if (pref == PhotoScale.CENTER_CROP && faceRect != null) {
+            if (applyFaceBiasedCenterCropMatrix(width, height, faceRect)) return
+        }
+
         foregroundImageView.scaleType = resolveForegroundScaleType(width, height)
     }
 
@@ -417,13 +448,15 @@ class ImagePlayerView : FrameLayout {
         }
 
     /**
-     * Compute the matrix scale factor and vertical overflow needed to pan a taller-than-container
-     * image vertically with the image-width matching the container width. Returns null when the
-     * container isn't measured yet or the image doesn't actually overflow vertically.
+     * Compute matrix scale + start/end translate-Y for a vertical pan on a taller-than-container
+     * image. When [subjectRect] is provided, the pan range is narrowed so subject + margin stays
+     * in view throughout, and direction is chosen so the pan starts from the side where the
+     * subject lives. Otherwise the full overflow is traversed with direction alternating per slot.
      */
     private fun prepareVerticalPan(
         imageWidth: Int,
         imageHeight: Int,
+        subjectRect: com.neilturner.aerialviews.models.videos.NormalizedRect? = null,
     ): KenBurnsSetup? {
         val view = foregroundImageView
         val containerW = view.width
@@ -432,7 +465,94 @@ class ImagePlayerView : FrameLayout {
         val scale = containerW.toFloat() / imageWidth.toFloat()
         val overflow = imageHeight.toFloat() * scale - containerH.toFloat()
         if (overflow <= 0f) return null
-        return KenBurnsSetup(scale = scale, overflow = overflow)
+
+        val (startY, endY) =
+            if (subjectRect != null) {
+                computeFaceBiasedPanRange(overflow, imageWidth.toFloat(), imageHeight.toFloat(), subjectRect)
+            } else {
+                val downward = (System.currentTimeMillis() / 1000L) % 2L == 0L
+                if (downward) Pair(0f, -overflow) else Pair(-overflow, 0f)
+            }
+        return KenBurnsSetup(scale = scale, overflow = overflow, startTranslateY = startY, endTranslateY = endY)
+    }
+
+    /**
+     * Work out pan start/end translate-Y around the face subject, starting from whichever
+     * end the face sits closer to. The allowed face-off-screen fraction (0..1 of face
+     * height) is read from [GeneralPrefs.photoScaleFaceOffScreenPercent]: 0 keeps face
+     * fully in view at pan extremes, larger values relax the constraint and widen the
+     * pan for a more cinematic "face enters / face leaves" feel.
+     */
+    private fun computeFaceBiasedPanRange(
+        overflowPx: Float,
+        imageWidthF: Float,
+        imageHeightF: Float,
+        face: com.neilturner.aerialviews.models.videos.NormalizedRect,
+    ): Pair<Float, Float> {
+        val offScreenFrac = (GeneralPrefs.photoScaleFaceOffScreenPercent.toIntOrNull() ?: 0)
+            .coerceIn(0, 100) / 100f
+        val marginFrac = -offScreenFrac * face.height
+        val view = foregroundImageView
+        val containerW = view.width.toFloat()
+        val containerH = view.height.toFloat()
+        // Band of the image (in image-y pixels) that fits in the container at any instant.
+        val bandImgY = containerH * imageWidthF / containerW
+        val total = imageHeightF // image-y total range (pixels)
+        val slide = total - bandImgY // how many image-y pixels the band can slide
+        if (slide <= 0f) return Pair(0f, 0f)
+
+        val faceTopPx = (face.top - marginFrac).coerceIn(0f, 1f) * total
+        val faceBotPx = (face.bottom + marginFrac).coerceIn(0f, 1f) * total
+        val faceCenterFrac = (face.top + face.bottom) / 2f
+
+        // Solve constraint: visible band [P*slide, P*slide+bandImgY] contains [faceTop, faceBot].
+        val pMinRaw = (faceBotPx - bandImgY) / slide
+        val pMaxRaw = faceTopPx / slide
+        val pMin = pMinRaw.coerceIn(0f, 1f)
+        val pMax = pMaxRaw.coerceIn(0f, 1f)
+
+        // If face + margin is bigger than the band, center the band on the face center.
+        val (pStart, pEnd) =
+            if (pMin > pMax) {
+                val pCenter = ((faceCenterFrac * total - bandImgY / 2f) / slide).coerceIn(0f, 1f)
+                Pair(pCenter, pCenter)
+            } else if (faceCenterFrac < 0.5f) {
+                Pair(pMin, pMax)
+            } else {
+                Pair(pMax, pMin)
+            }
+        // translateY = -P * overflow (because larger P means image scrolled up more)
+        return Pair(-pStart * overflowPx, -pEnd * overflowPx)
+    }
+
+    /**
+     * Place the portrait image with MATRIX scale type biased toward the face — subject's
+     * eye-line near the rule-of-thirds mark (1/3 from top of visible band). Returns false
+     * if the container isn't measured yet, so the caller can fall back to plain CENTER_CROP.
+     */
+    private fun applyFaceBiasedCenterCropMatrix(
+        imageWidth: Int,
+        imageHeight: Int,
+        face: com.neilturner.aerialviews.models.videos.NormalizedRect,
+    ): Boolean {
+        val view = foregroundImageView
+        val containerW = view.width
+        val containerH = view.height
+        if (containerW <= 0 || containerH <= 0 || imageWidth <= 0 || imageHeight <= 0) return false
+        val scale = containerW.toFloat() / imageWidth.toFloat()
+        val overflow = imageHeight.toFloat() * scale - containerH.toFloat()
+        if (overflow <= 0f) return false
+
+        val bandImgY = containerH.toFloat() * imageWidth.toFloat() / containerW.toFloat()
+        val slide = imageHeight.toFloat() - bandImgY
+        // Target: face center at 1/3 from top of visible band.
+        val faceCy = (face.top + face.bottom) / 2f
+        val p = ((faceCy * imageHeight.toFloat() - bandImgY / 3f) / slide).coerceIn(0f, 1f)
+
+        val setup = KenBurnsSetup(scale = scale, overflow = overflow, startTranslateY = 0f, endTranslateY = 0f)
+        foregroundImageView.scaleType = ImageView.ScaleType.MATRIX
+        applyVerticalPanMatrix(setup, -p * overflow)
+        return true
     }
 
     private fun applyVerticalPanMatrix(
@@ -448,12 +568,9 @@ class ImagePlayerView : FrameLayout {
     private fun startKenBurnsIfPending(durationMs: Long) {
         val setup = pendingKenBurns ?: return
         if (durationMs <= 0) return
-        // Alternate start direction per slot for visual variety.
-        val downward = (System.currentTimeMillis() / 1000L) % 2L == 0L
-        val startY = if (downward) 0f else -setup.overflow
-        val endY = if (downward) -setup.overflow else 0f
+        if (setup.startTranslateY == setup.endTranslateY) return // face too big to pan — stay static
         kenBurnsAnimator =
-            ValueAnimator.ofFloat(startY, endY).apply {
+            ValueAnimator.ofFloat(setup.startTranslateY, setup.endTranslateY).apply {
                 duration = durationMs
                 interpolator = LinearInterpolator()
                 addUpdateListener { applyVerticalPanMatrix(setup, it.animatedValue as Float) }

--- a/app/src/main/java/com/neilturner/aerialviews/ui/core/ImagePlayerView.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/ui/core/ImagePlayerView.kt
@@ -119,7 +119,18 @@ class ImagePlayerView : FrameLayout {
                 add(buildGifDecoder())
             }.build()
 
-    fun setImage(media: AerialMedia) {
+    fun setImage(mediaParam: AerialMedia) {
+        // If this logical slot carries alternates (e.g. other members of a temporal
+        // cluster from the Immich smart slideshow), pick one at random every time
+        // the slot is rendered so the user sees variety across playlist loops.
+        val media =
+            if (mediaParam.clusterAlternates.isNotEmpty()) {
+                val all = listOf(mediaParam.uri) + mediaParam.clusterAlternates
+                val chosen = all.random()
+                if (chosen == mediaParam.uri) mediaParam else mediaParam.copy(uri = chosen)
+            } else {
+                mediaParam
+            }
         ioScope.launch {
             val baseStream = ImagePlayerHelper.streamFromMedia(context, media)
             if (baseStream == null) {

--- a/app/src/main/java/com/neilturner/aerialviews/ui/core/ScreenController.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/ui/core/ScreenController.kt
@@ -52,6 +52,7 @@ import com.neilturner.aerialviews.utils.GradientHelper
 import com.neilturner.aerialviews.utils.OverlayHelper
 import com.neilturner.aerialviews.utils.PermissionHelper
 import com.neilturner.aerialviews.utils.RefreshRateHelper
+import com.neilturner.aerialviews.utils.SplashCache
 import com.neilturner.aerialviews.utils.ToastHelper
 import com.neilturner.aerialviews.utils.WindowHelper
 import kotlinx.coroutines.CoroutineScope
@@ -235,6 +236,9 @@ class ScreenController(
             gradientBottomView.background = GradientHelper.smoothBackgroundAlt(GradientDrawable.Orientation.BOTTOM_TOP)
             gradientBottomView.visibility = View.VISIBLE
         }
+
+        // Show a previously-cached photo behind the loading UI instead of a black screen.
+        SplashCache.loadBitmap(context)?.let(imagePlayer::showSplashBitmap)
 
         mainScope.launch {
             // Launch if we have permission

--- a/app/src/main/java/com/neilturner/aerialviews/utils/SplashCache.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/utils/SplashCache.kt
@@ -1,0 +1,50 @@
+package com.neilturner.aerialviews.utils
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import timber.log.Timber
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Stores a single JPEG snapshot of a recently-shown slideshow photo so the next
+ * screensaver start can display it behind the loading UI instead of a black screen.
+ *
+ * Intentionally keeps exactly one file (overwritten each time) — across sessions the
+ * saved photo naturally changes because different sessions capture different slots.
+ * Writes are deliberately infrequent (the caller decides cadence) to be gentle on
+ * device flash.
+ */
+object SplashCache {
+    private const val FILE_NAME = "loading_splash.jpg"
+    private const val JPEG_QUALITY = 80
+
+    private fun file(context: Context): File = File(context.cacheDir, FILE_NAME)
+
+    fun save(
+        context: Context,
+        bitmap: Bitmap,
+    ) {
+        if (bitmap.isRecycled) return
+        try {
+            FileOutputStream(file(context)).use { out ->
+                bitmap.compress(Bitmap.CompressFormat.JPEG, JPEG_QUALITY, out)
+            }
+            Timber.i("SplashCache: saved (${bitmap.width}x${bitmap.height})")
+        } catch (e: Exception) {
+            Timber.w(e, "SplashCache: save failed")
+        }
+    }
+
+    fun loadBitmap(context: Context): Bitmap? {
+        val f = file(context)
+        if (!f.exists() || f.length() == 0L) return null
+        return try {
+            BitmapFactory.decodeFile(f.absolutePath)
+        } catch (e: Exception) {
+            Timber.w(e, "SplashCache: load failed")
+            null
+        }
+    }
+}

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1171,6 +1171,21 @@
         <item>1440</item>
     </string-array>
 
+    <string-array name="photo_scale_face_off_screen_entries" translatable="false">
+        <item>Face fully in view</item>
+        <item>Up to 10% off-screen</item>
+        <item>Up to 20% off-screen</item>
+        <item>Up to 30% off-screen</item>
+        <item>Up to 40% off-screen</item>
+    </string-array>
+    <string-array name="photo_scale_face_off_screen_values" translatable="false">
+        <item>0</item>
+        <item>10</item>
+        <item>20</item>
+        <item>30</item>
+        <item>40</item>
+    </string-array>
+
     <string-array name="immich_smart_slideshow_exempt_percent_entries" translatable="false">
         <item>100% (keep all)</item>
         <item>75%</item>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1151,6 +1151,38 @@
     <string name="immich_include_recent_default" translatable="false">DISABLED</string>
     <string name="immich_include_favorites_default" translatable="false">DISABLED</string>
 
+    <string-array name="immich_smart_slideshow_gap_entries" translatable="false">
+        <item>1 minute</item>
+        <item>10 minutes</item>
+        <item>30 minutes</item>
+        <item>1 hour</item>
+        <item>6 hours</item>
+        <item>1 day</item>
+    </string-array>
+    <string-array name="immich_smart_slideshow_gap_values" translatable="false">
+        <item>1</item>
+        <item>10</item>
+        <item>30</item>
+        <item>60</item>
+        <item>360</item>
+        <item>1440</item>
+    </string-array>
+
+    <string-array name="immich_smart_slideshow_exempt_percent_entries" translatable="false">
+        <item>100% (keep all)</item>
+        <item>75%</item>
+        <item>50%</item>
+        <item>25%</item>
+        <item>10%</item>
+    </string-array>
+    <string-array name="immich_smart_slideshow_exempt_percent_values" translatable="false">
+        <item>100</item>
+        <item>75</item>
+        <item>50</item>
+        <item>25</item>
+        <item>10</item>
+    </string-array>
+
     <string name="immich_img_preview">Preview</string>
     <string name="immich_img_fullsize">Fullsize</string>
     <string name="immich_img_original">Original</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -759,13 +759,16 @@
     <!-- Photo scale/fill options -->
     <string name="photo_scale_fill_crop">Fill with crop*</string>
     <string name="photo_scale_no_crop">Scale without crop</string>
+    <string name="photo_scale_ken_burns_vertical">Pan vertically*</string>
     <string-array name="photo_scale_entries" translatable="false">
         <item>@string/photo_scale_fill_crop</item>
         <item>@string/photo_scale_no_crop</item>
+        <item>@string/photo_scale_ken_burns_vertical</item>
     </string-array>
     <string-array name="photo_scale_values" translatable="false">
         <item>CENTER_CROP</item>
         <item>FIT_CENTER</item>
+        <item>KEN_BURNS_VERTICAL</item>
     </string-array>
     <string name="photo_scale_default" translatable="false">CENTER_CROP</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -654,6 +654,10 @@
     <string name="appearance_video_scale_title">Video scaling</string>
     <string name="appearance_photo_scale_landscape_title">Landscape Photo scaling</string>
     <string name="appearance_photo_scale_portrait_title">Portrait Photo scaling</string>
+    <string name="appearance_photo_scale_face_aware_title">Face-aware portrait crop</string>
+    <string name="appearance_photo_scale_face_aware_summary">Use detected face bounding boxes (Immich only) to bias portrait center-crop placement and narrow Ken Burns pan so the largest face stays on-screen. Landscape photos unaffected.</string>
+    <string name="appearance_photo_scale_face_off_screen_title">Face off-screen at pan extremes</string>
+    <string name="appearance_photo_scale_face_off_screen_summary">How much of the face is allowed to slip off the viewport at the ends of a Ken Burns pan. Larger values give a wider, more cinematic pan at the cost of face not always being fully visible.</string>
     <string name="category_background_blur">Background blur</string>
     <string name="appearance_photo_background_blur_title">Enable background blur</string>
     <string name="appearance_photo_background_blur_summary">Show a blurred version of the photo behind the foreground image to fill empty areas</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -358,6 +358,16 @@
     <string name="immich_media_include_random_title">Include random photos</string>
     <string name="immich_media_include_recent_title">Include recent photos</string>
 
+    <string name="immich_smart_slideshow_title">Smart slideshow</string>
+    <string name="immich_smart_slideshow_summary">Collapse photos taken close in time into one slot so bursts and event photos don\'t dominate the mix</string>
+    <string name="immich_smart_slideshow_gap_title">Clustering window</string>
+    <string name="immich_smart_slideshow_gap_summary">Photos within this time window are treated as one moment (one random representative is shown)</string>
+    <string name="immich_smart_slideshow_exempt_title">Exempt album name pattern (regex)</string>
+    <string name="immich_smart_slideshow_exempt_summary">Albums whose names match this regex will bypass clustering (use for film scans etc. where timestamps lie)</string>
+    <string name="immich_smart_slideshow_exempt_percent_title">Keep exempt photos</string>
+    <string name="immich_smart_slideshow_exempt_percent_summary">How many of the exempt-album photos to keep in the playlist (random sample)</string>
+    <string name="category_immich_smart_slideshow">Smart slideshow</string>
+
     <string name="immich_media_test_summary1">Files found: %1$s</string>
     <string name="immich_media_test_summary2">Unsupported files: %1$s</string>
     <string name="immich_media_test_summary3">Videos found: %1$s</string>

--- a/app/src/main/res/xml/settings_appearance_scaling.xml
+++ b/app/src/main/res/xml/settings_appearance_scaling.xml
@@ -26,6 +26,23 @@
                     app:key="photo_scale_portrait"
                     app:title="@string/appearance_photo_scale_portrait_title"
                     app:useSimpleSummaryProvider="true" />
+
+                <SwitchPreferenceCompat
+                    app:defaultValue="false"
+                    app:key="photo_scale_face_aware"
+                    app:title="@string/appearance_photo_scale_face_aware_title"
+                    app:summary="@string/appearance_photo_scale_face_aware_summary" />
+
+                <ListPreference
+                    app:dependency="photo_scale_face_aware"
+                    app:disableDependentsState="false"
+                    app:defaultValue="0"
+                    app:entries="@array/photo_scale_face_off_screen_entries"
+                    app:entryValues="@array/photo_scale_face_off_screen_values"
+                    app:key="photo_scale_face_off_screen_percent"
+                    app:title="@string/appearance_photo_scale_face_off_screen_title"
+                    app:summary="@string/appearance_photo_scale_face_off_screen_summary"
+                    app:useSimpleSummaryProvider="true" />
         </PreferenceCategory>
 
         <PreferenceCategory app:title="@string/category_background_blur">

--- a/app/src/main/res/xml/sources_immich_videos.xml
+++ b/app/src/main/res/xml/sources_immich_videos.xml
@@ -126,6 +126,46 @@
                     app:useSimpleSummaryProvider="true" />
         </PreferenceCategory>
 
+        <PreferenceCategory app:title="@string/category_immich_smart_slideshow">
+                <SwitchPreference
+                    app:dependency="immich_media_enabled"
+                    app:defaultValue="false"
+                    app:key="immich_smart_slideshow_enabled"
+                    app:title="@string/immich_smart_slideshow_title"
+                    app:summary="@string/immich_smart_slideshow_summary" />
+
+                <ListPreference
+                    app:dependency="immich_smart_slideshow_enabled"
+                    app:disableDependentsState="false"
+                    app:defaultValue="30"
+                    app:entries="@array/immich_smart_slideshow_gap_entries"
+                    app:entryValues="@array/immich_smart_slideshow_gap_values"
+                    app:key="immich_smart_slideshow_gap_minutes"
+                    app:title="@string/immich_smart_slideshow_gap_title"
+                    app:summary="@string/immich_smart_slideshow_gap_summary"
+                    app:useSimpleSummaryProvider="true" />
+
+                <EditTextPreference
+                    app:dependency="immich_smart_slideshow_enabled"
+                    app:disableDependentsState="false"
+                    app:defaultValue=""
+                    app:key="immich_smart_slideshow_exempt_pattern"
+                    app:title="@string/immich_smart_slideshow_exempt_title"
+                    app:summary="@string/immich_smart_slideshow_exempt_summary"
+                    android:selectAllOnFocus="true" />
+
+                <ListPreference
+                    app:dependency="immich_smart_slideshow_enabled"
+                    app:disableDependentsState="false"
+                    app:defaultValue="100"
+                    app:entries="@array/immich_smart_slideshow_exempt_percent_entries"
+                    app:entryValues="@array/immich_smart_slideshow_exempt_percent_values"
+                    app:key="immich_smart_slideshow_exempt_percent"
+                    app:title="@string/immich_smart_slideshow_exempt_percent_title"
+                    app:summary="@string/immich_smart_slideshow_exempt_percent_summary"
+                    app:useSimpleSummaryProvider="true" />
+        </PreferenceCategory>
+
         <PreferenceCategory app:title="@string/category_advanced">
                 <ListPreference
                     app:dependency="immich_media_enabled"


### PR DESCRIPTION
Three portrait-oriented UX improvements bundled in one branch because they share the same renderer plumbing and two of them share data flow:

  1. Add vertical Ken Burns pan as a portrait scale mode — new PhotoScale.KEN_BURNS_VERTICAL option alongside CENTER_CROP / FIT_CENTER. Portrait photos slowly pan top-to-bottom (or reverse) over the slot duration via ImagePlayerView matrix animation, revealing the full image
  instead of crop-to-center losing the top/bottom thirds. Landscape images with the mode selected fall back to center-crop.
  2. Face-aware center crop and Ken Burns pan for Immich portraits — opt-in toggle using Immich's ML face detection. Portrait + face-aware toggle:
    - CENTER_CROP: MATRIX-positioned so the face's y-center sits at the rule-of-thirds line.
    - KEN_BURNS_VERTICAL: pan range is narrowed so the largest face stays in view throughout, direction chosen so pan starts from whichever side the face lives. Configurable "face allowed off-screen percent at pan extremes" (0–40%, default 0 = strict, higher = wider more
  cinematic pan).
  3. Show previously-cached photo as loading splash — during the initial fetch, paint a JPEG snapshot of a recently-shown photo behind the loading UI instead of a black rectangle. Saves at most one snapshot per ~50 rendered photos to go easy on flash. No new preferences.

  Why this branch is based on smart-slideshow (#341), not upstream/master

  Commit 2 requires the clusterAlternates data model introduced by #341. When the Immich smart slideshow collapses a temporal burst into one slot, the cluster members now each need to carry their own face bbox (cluster gap can be up to 1 day, so alternates are often entirely
  different scenes). This branch refactors clusterAlternates: List<Uri> into List<ClusterAlternate> where each entry carries an optional NormalizedRect.

  If #341 is merged first, the apparent size of this PR will shrink by those 2 commits. If there's a different preference — e.g. rebase commit 1 and 3 onto master since they don't depend on #341, and leave commit 2 stacked — happy to split.

  Immich API quirk encountered

  people[].faces[] is only populated by GET /api/assets/{id} in Immich 2.7.5. The batch /api/albums/{id} and /api/search/metadata endpoints return the field with an empty array even when withPeople: true or withFaces: true is passed. So enrichment makes one detail call per
  portrait asset — parallelised, this adds ~1–3 s of startup time for ~900 portraits on LAN. Feature is opt-in to make the cost optional.

  Face bounding boxes come from asset_face.imageWidth/imageHeight (the ML-preview frame Immich decoded on), not asset.width/height. Normalizing against the wrong dimensions gives consistently shifted boxes — documented inline.

  Testing status

  - Commit 1 (Ken Burns pan) — tested live on an Nvidia Shield. Pan respects slideshow speed, pause/resume, skip. Landscape images unaffected.
  - Commit 2 (Face-aware) — tested live with Immich 2.7.5. Pan mathematically constrained to keep face in viewport at default 0% off-screen setting.
  - Commit 3 (Splash) — untested end-to-end yet (haven't had a startup with a cached file present). Logic review is clean; save path fires from ImagePlayerView.runSetupFinishedRunnable, load path fires from ScreenController.init before the media fetch. Fixes likely.

  Expected adjustments before removing draft status

  - More live testing of splash on first reboot after warm-up.
  - Commit messages may get rewritten for upstream taste.
  - Would welcome maintainer input on whether splash should be a separate PR — I bundled because the implementation touches ImagePlayerView / ScreenController that the other two commits already modify, but it's functionally orthogonal.