### PR TITLE
Add photo support to custom feed parser

### DIFF
--- a/app/src/main/java/com/neilturner/aerialviews/models/videos/Comm1Photo.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/models/videos/Comm1Photo.kt
@@ -1,0 +1,27 @@
+package com.neilturner.aerialviews.models.videos
+
+import android.net.Uri
+import androidx.core.net.toUri
+import com.neilturner.aerialviews.models.enums.VideoQuality
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+class Comm1Photo {
+    @SerialName("url-1080")
+    val url1080: String? = null
+
+    @SerialName("url-4K")
+    val url4k: String? = null
+
+    val title: String = ""
+
+    fun uriAtQuality(quality: VideoQuality?): Uri {
+        val url =
+            when (quality) {
+                VideoQuality.VIDEO_4K_SDR, VideoQuality.VIDEO_4K_HDR -> url4k ?: url1080
+                else -> url1080 ?: url4k
+            }.orEmpty()
+        return url.toUri()
+    }
+}

--- a/app/src/main/java/com/neilturner/aerialviews/providers/custom/CustomFeedApi.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/providers/custom/CustomFeedApi.kt
@@ -1,5 +1,6 @@
 package com.neilturner.aerialviews.providers.custom
 
+import com.neilturner.aerialviews.models.videos.Comm1Photo
 import com.neilturner.aerialviews.models.videos.Comm1Video
 import kotlinx.serialization.Serializable
 import retrofit2.http.GET
@@ -25,6 +26,7 @@ interface CustomFeedApi {
 @Serializable
 data class FeedVideos(
     val assets: List<Comm1Video>? = null,
+    val photos: List<Comm1Photo>? = null,
 )
 
 @Serializable

--- a/app/src/main/java/com/neilturner/aerialviews/providers/custom/CustomFeedProvider.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/providers/custom/CustomFeedProvider.kt
@@ -11,6 +11,7 @@ import com.neilturner.aerialviews.models.enums.SceneType
 import com.neilturner.aerialviews.models.enums.TimeOfDay
 import com.neilturner.aerialviews.models.enums.VideoQuality
 import com.neilturner.aerialviews.models.prefs.CustomFeedPrefs
+import com.neilturner.aerialviews.models.videos.AerialExifMetadata
 import com.neilturner.aerialviews.models.videos.AerialMedia
 import com.neilturner.aerialviews.models.videos.AerialMediaMetadata
 import com.neilturner.aerialviews.providers.MediaProvider
@@ -512,6 +513,10 @@ class CustomFeedProvider(
                                 metadata =
                                     AerialMediaMetadata(
                                         shortDescription = photo.title,
+                                        // Photos have no per-timestamp POI/short-description overlay option
+                                        // (that path is video-only), so surface the feed title via the EXIF
+                                        // "description" field, which the default photo overlay already displays.
+                                        exif = AerialExifMetadata(description = photo.title),
                                         timeOfDay = TimeOfDay.UNKNOWN,
                                         scene = SceneType.UNKNOWN,
                                     ),

--- a/app/src/main/java/com/neilturner/aerialviews/providers/custom/CustomFeedProvider.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/providers/custom/CustomFeedProvider.kt
@@ -249,16 +249,17 @@ class CustomFeedProvider(
                     continue
                 }
 
-                // Check if URL ends with entries.json - parse it directly for videos
+                // Check if URL ends with entries.json - parse it directly for media
                 if (url.endsWith("entries.json", ignoreCase = true)) {
                     try {
                         val customVideos = customFeedApi.getVideos(url)
                         val videoCount = customVideos.assets?.size ?: 0
-                        if (videoCount > 0) {
+                        val photoCount = customVideos.photos?.size ?: 0
+                        if (videoCount + photoCount > 0) {
                             validEntriesUrls.add(url)
-                            Timber.i("Found $videoCount videos in entries.json: $url")
+                            Timber.i("Found $videoCount videos and $photoCount photos in entries.json: $url")
                         } else {
-                            errorMessages[url] = "entries.json contains no videos"
+                            errorMessages[url] = "entries.json contains no media"
                         }
                     } catch (e: Exception) {
                         errorMessages[url] = "Failed to parse entries.json: ${e.message}"
@@ -289,16 +290,19 @@ class CustomFeedProvider(
             }
         }
 
-        // Count total videos from valid entries.json URLs
+        // Count total videos and photos from valid entries.json URLs
         var totalVideos = 0
+        var totalPhotos = 0
         for (entriesUrl in validEntriesUrls) {
             try {
                 val customVideos = customFeedApi.getVideos(entriesUrl)
                 val videoCount = customVideos.assets?.size ?: 0
+                val photoCount = customVideos.photos?.size ?: 0
                 totalVideos += videoCount
-                Timber.d("Found $videoCount videos in $entriesUrl")
+                totalPhotos += photoCount
+                Timber.d("Found $videoCount videos and $photoCount photos in $entriesUrl")
             } catch (e: Exception) {
-                Timber.w(e, "Failed to count videos from: $entriesUrl")
+                Timber.w(e, "Failed to count media from: $entriesUrl")
             }
         }
         var totalCsvVideos = 0
@@ -314,6 +318,7 @@ class CustomFeedProvider(
             }
         }
         totalVideos += totalCsvVideos
+        totalPhotos += totalCsvPhotos
 
         // Save valid URLs to cache
         val allValidUrls =
@@ -351,8 +356,8 @@ class CustomFeedProvider(
                     if (validCsvUrls.isNotEmpty()) {
                         append("• ${validCsvUrls.size} CSV media lists\n")
                     }
-                    if (totalCsvPhotos > 0) {
-                        append("• $totalCsvPhotos photos found\n")
+                    if (totalPhotos > 0) {
+                        append("• $totalPhotos photos found\n")
                     }
 
                     if (errorMessages.isNotEmpty()) {
@@ -377,8 +382,8 @@ class CustomFeedProvider(
                     if (validHlsUrls.isNotEmpty()) {
                         parts.add("${validHlsUrls.size} HLS stream${if (validHlsUrls.size != 1) "s" else ""}")
                     }
-                    if (totalCsvPhotos > 0) {
-                        parts.add("$totalCsvPhotos photo${if (totalCsvPhotos != 1) "s" else ""}")
+                    if (totalPhotos > 0) {
+                        parts.add("$totalPhotos photo${if (totalPhotos != 1) "s" else ""}")
                     }
                     append(parts.joinToString(", "))
                 }
@@ -497,7 +502,28 @@ class CustomFeedProvider(
                     }
                 }
 
-                Timber.d("Processed ${customVideos.assets?.size ?: 0} videos from $url")
+                customVideos.photos?.forEach { photo ->
+                    if (prefs.enabled) {
+                        videos.add(
+                            AerialMedia(
+                                photo.uriAtQuality(quality),
+                                type = AerialMediaType.IMAGE,
+                                source = AerialMediaSource.CUSTOM,
+                                metadata =
+                                    AerialMediaMetadata(
+                                        shortDescription = photo.title,
+                                        timeOfDay = TimeOfDay.UNKNOWN,
+                                        scene = SceneType.UNKNOWN,
+                                    ),
+                            ),
+                        )
+                    }
+                }
+
+                Timber.d(
+                    "Processed ${customVideos.assets?.size ?: 0} videos and " +
+                        "${customVideos.photos?.size ?: 0} photos from $url",
+                )
             } catch (e: Exception) {
                 Timber.w(e, "Failed to parse entries from URL: $url")
             }

--- a/app/src/main/java/com/neilturner/aerialviews/providers/custom/CustomFeedProvider.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/providers/custom/CustomFeedProvider.kt
@@ -345,7 +345,7 @@ class CustomFeedProvider(
                         append("• $totalVideos videos found\n")
                     }
                     if (validEntriesUrls.isNotEmpty()) {
-                        append("• ${validEntriesUrls.size} video feeds\n")
+                        append("• ${validEntriesUrls.size} feeds\n")
                     }
                     if (validRtspUrls.isNotEmpty()) {
                         append("• ${validRtspUrls.size} RTSP streams\n")

--- a/app/src/main/java/com/neilturner/aerialviews/ui/core/ImagePlayerHelper.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/ui/core/ImagePlayerHelper.kt
@@ -111,6 +111,12 @@ internal object ImagePlayerHelper {
                     context.contentResolver.openInputStream(finalUri)
                 }
 
+                "http", "https" -> {
+                    // Remote images are fetched directly by Coil's network loader,
+                    // so there's no local stream to open here.
+                    null
+                }
+
                 else -> {
                     Timber.e("Unsupported URI scheme: ${uri.scheme}")
                     null

--- a/app/src/main/java/com/neilturner/aerialviews/ui/core/ImagePlayerView.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/ui/core/ImagePlayerView.kt
@@ -392,7 +392,9 @@ class ImagePlayerView : FrameLayout {
 
     private fun onPlayerError() {
         removeCallbacks(finishedRunnable)
-        postDelayed(errorRunnable, ScreenController.ERROR_DELAY)
+        // Notify immediately; the single error backoff is applied by
+        // ScreenController.handleError(). Delaying here too would double it.
+        post(errorRunnable)
     }
 
     fun setOnPlayerListener(listener: ScreenController) {

--- a/app/src/test/java/com/neilturner/aerialviews/providers/custom/CustomFeedPhotoTest.kt
+++ b/app/src/test/java/com/neilturner/aerialviews/providers/custom/CustomFeedPhotoTest.kt
@@ -1,0 +1,136 @@
+package com.neilturner.aerialviews.providers.custom
+
+import android.net.Uri
+import com.neilturner.aerialviews.models.enums.VideoQuality
+import com.neilturner.aerialviews.models.videos.Comm1Photo
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkStatic
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class CustomFeedPhotoTest {
+    // Mirrors the production JsonHelper configuration used to parse custom feeds
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    @Test
+    fun `parses photos array with urls and title, ignoring unknown fields`() {
+        val body =
+            """
+            {
+              "category": "art-gallery",
+              "name": "Art Gallery",
+              "count": 1,
+              "photos": [
+                {
+                  "id": "ART_1",
+                  "source": 9,
+                  "url-1080": "https://example.com/art-1080.jpg",
+                  "url-4K": "https://example.com/art-4k.jpg",
+                  "title": "A lovely painting",
+                  "attribution": "Museum",
+                  "added": "2026-07-04"
+                }
+              ]
+            }
+            """.trimIndent()
+
+        val feed = json.decodeFromString<FeedVideos>(body)
+
+        assertNull(feed.assets)
+        assertEquals(1, feed.photos?.size)
+        val photo = feed.photos!!.single()
+        assertEquals("https://example.com/art-1080.jpg", photo.url1080)
+        assertEquals("https://example.com/art-4k.jpg", photo.url4k)
+        assertEquals("A lovely painting", photo.title)
+    }
+
+    @Test
+    fun `parses a feed containing both videos and photos`() {
+        val body =
+            """
+            {
+              "assets": [
+                { "url-1080-SDR": "https://example.com/video-1080.mp4", "url-4K-SDR": "https://example.com/video-4k.mp4" }
+              ],
+              "photos": [
+                { "url-1080": "https://example.com/photo.jpg", "title": "Photo" }
+              ]
+            }
+            """.trimIndent()
+
+        val feed = json.decodeFromString<FeedVideos>(body)
+
+        assertEquals(1, feed.assets?.size)
+        assertEquals(1, feed.photos?.size)
+        assertEquals("Photo", feed.photos!!.single().title)
+    }
+
+    @Test
+    fun `photos are null when only videos are present`() {
+        val body = """{ "assets": [ { "url-1080-SDR": "https://example.com/v.mp4" } ] }"""
+
+        val feed = json.decodeFromString<FeedVideos>(body)
+
+        assertEquals(1, feed.assets?.size)
+        assertNull(feed.photos)
+    }
+
+    @BeforeEach
+    fun mockUri() {
+        mockkStatic(Uri::class)
+    }
+
+    @AfterEach
+    fun unmockUri() {
+        unmockkStatic(Uri::class)
+    }
+
+    private fun urlChosenFor(
+        photoJson: String,
+        quality: VideoQuality?,
+    ): String {
+        val urlSlot = slot<String>()
+        every { Uri.parse(capture(urlSlot)) } returns mockk(relaxed = true)
+        val photo = json.decodeFromString<Comm1Photo>(photoJson)
+        photo.uriAtQuality(quality)
+        return urlSlot.captured
+    }
+
+    private val bothQualities =
+        """{ "url-1080": "https://example.com/1080.jpg", "url-4K": "https://example.com/4k.jpg" }"""
+
+    @Test
+    fun `4K quality selects the 4K url`() {
+        assertEquals("https://example.com/4k.jpg", urlChosenFor(bothQualities, VideoQuality.VIDEO_4K_SDR))
+        assertEquals("https://example.com/4k.jpg", urlChosenFor(bothQualities, VideoQuality.VIDEO_4K_HDR))
+    }
+
+    @Test
+    fun `1080 quality selects the 1080 url`() {
+        assertEquals("https://example.com/1080.jpg", urlChosenFor(bothQualities, VideoQuality.VIDEO_1080_SDR))
+    }
+
+    @Test
+    fun `null quality defaults to the 1080 url`() {
+        assertEquals("https://example.com/1080.jpg", urlChosenFor(bothQualities, null))
+    }
+
+    @Test
+    fun `4K quality falls back to 1080 when 4K is missing`() {
+        val onlyHd = """{ "url-1080": "https://example.com/1080.jpg" }"""
+        assertEquals("https://example.com/1080.jpg", urlChosenFor(onlyHd, VideoQuality.VIDEO_4K_SDR))
+    }
+
+    @Test
+    fun `1080 quality falls back to 4K when 1080 is missing`() {
+        val only4k = """{ "url-4K": "https://example.com/4k.jpg" }"""
+        assertEquals("https://example.com/4k.jpg", urlChosenFor(only4k, VideoQuality.VIDEO_1080_SDR))
+    }
+}


### PR DESCRIPTION
Custom feed entries files can now include a 'photos' array alongside the existing 'assets' (videos) array. Each photo exposes 'url-1080', 'url-4K', and 'title', reusing the existing schema and is added as an 'IMAGE' media item using 'AerialMediaSource.CUSTOM'.
Photo resolution reuses the existing custom-feed quality preference: 4K-tier prefs pick 'url-4K', resolving to the highest quality photo avaliable, otherwise 'url-1080' (each falls back to the other if missing).
