### PR TITLE
Fix 4K decoder recovery on TV transitions

### DIFF
--- a/app/src/main/java/com/neilturner/aerialviews/ui/core/ScreenController.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/ui/core/ScreenController.kt
@@ -643,7 +643,7 @@ class ScreenController(
             }.withEndAction {
                 // Hide content views after faded out
                 videoViewBinding.root.visibility = View.INVISIBLE
-                videoViewBinding.videoPlayer.stop()
+                // Let setVideo() replace the source without forcing a Realtek codec teardown.
 
                 imageViewBinding.root.visibility = View.INVISIBLE
                 imageViewBinding.imagePlayer.stop()
@@ -1072,6 +1072,8 @@ class ScreenController(
     private fun handleError() {
         if (blackOutMode) return
 
+        recreateVideoPlayer()
+
         mainScope.launch {
             delay(ERROR_DELAY.milliseconds)
             if (loadingView.isVisible) {
@@ -1081,6 +1083,19 @@ class ScreenController(
                 fadeOutCurrentItem()
             }
         }
+    }
+
+    private fun recreateVideoPlayer() {
+        val videoContainer = videoViewBinding.root as ViewGroup
+        videoPlayer.release()
+        videoContainer.removeAllViews()
+
+        val layoutRes =
+            if (GeneralPrefs.useTextureViewForVideo) R.layout.video_view_texture else R.layout.video_view
+        val replacement = LayoutInflater.from(context).inflate(layoutRes, videoContainer, false)
+        videoContainer.addView(replacement)
+        videoPlayer = VideoViewBinding.bind(replacement).videoPlayer
+        videoPlayer.setOnPlayerListener(this)
     }
 
     private fun handlePlaybackSpeedChanged() {

--- a/app/src/main/java/com/neilturner/aerialviews/ui/core/ScreenController.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/ui/core/ScreenController.kt
@@ -113,7 +113,7 @@ class ScreenController(
     private val metadataJobs = mutableMapOf<OverlayType, Job>()
     private var currentMedia: AerialMedia? = null
     private val cacheRepository = PlaylistCacheRepository(context)
-    private val videoViewBinding: VideoViewBinding
+    private lateinit var videoViewBinding: VideoViewBinding
     private val imageViewBinding: ImageViewBinding
     private val overlayViewBinding: OverlayViewBinding
     private val loadingView: View
@@ -1086,15 +1086,18 @@ class ScreenController(
     }
 
     private fun recreateVideoPlayer() {
-        val videoContainer = videoViewBinding.root as ViewGroup
+        val oldRoot = videoViewBinding.root
+        val videoParent = oldRoot.parent as? ViewGroup ?: return
+        val index = videoParent.indexOfChild(oldRoot)
         videoPlayer.release()
-        videoContainer.removeAllViews()
+        videoParent.removeView(oldRoot)
 
         val layoutRes =
             if (GeneralPrefs.useTextureViewForVideo) R.layout.video_view_texture else R.layout.video_view
-        val replacement = LayoutInflater.from(context).inflate(layoutRes, videoContainer, false)
-        videoContainer.addView(replacement)
-        videoPlayer = VideoViewBinding.bind(replacement).videoPlayer
+        val replacement = LayoutInflater.from(context).inflate(layoutRes, videoParent, false)
+        videoParent.addView(replacement, index)
+        videoViewBinding = VideoViewBinding.bind(replacement)
+        videoPlayer = videoViewBinding.videoPlayer
         videoPlayer.setOnPlayerListener(this)
     }
 

--- a/app/src/main/java/com/neilturner/aerialviews/ui/core/VideoPlayerView.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/ui/core/VideoPlayerView.kt
@@ -90,7 +90,7 @@ class VideoPlayerView
                 exoPlayer.release()
             }
 
-            exoPlayer = VideoPlayerHelper.buildPlayer(context, GeneralPrefs)
+            exoPlayer = VideoPlayerHelper.buildPlayer(context.applicationContext, GeneralPrefs)
             player = exoPlayer
             player?.addListener(this)
             player?.repeatMode = Player.REPEAT_MODE_OFF
@@ -336,8 +336,7 @@ class VideoPlayerView
             removeCallbacks(almostFinishedRunnable)
             FirebaseHelper.crashlyticsException(error.cause)
 
-            // Allow the TV's asynchronous codec and graphic buffers to finish releasing.
-            postDelayed(onErrorRunnable, 5_000)
+            post(onErrorRunnable)
         }
 
         override fun onPlayerErrorChanged(error: PlaybackException?) {

--- a/app/src/main/java/com/neilturner/aerialviews/ui/core/VideoPlayerView.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/ui/core/VideoPlayerView.kt
@@ -42,7 +42,7 @@ class VideoPlayerView
         defStyleAttr: Int = 0,
     ) : PlayerView(context.applicationContext, attrs, defStyleAttr),
         Player.Listener {
-        private val exoPlayer: ExoPlayer
+        private lateinit var exoPlayer: ExoPlayer
         private var state = VideoState()
 
         private var listener: OnVideoPlayerEventListener? = null
@@ -76,16 +76,24 @@ class VideoPlayerView
 
         init {
             // Use applicationContext to prevent activity context leaks
-            exoPlayer = VideoPlayerHelper.buildPlayer(context, GeneralPrefs)
-
-            player = exoPlayer
-            player?.addListener(this)
-
-            player?.repeatMode = Player.REPEAT_MODE_OFF
+            replacePlayer(context)
 
             controllerAutoShow = false
             useController = false
             resizeMode = VideoPlayerHelper.getResizeMode(GeneralPrefs.videoScale)
+        }
+
+        private fun replacePlayer(context: Context) {
+            if (::exoPlayer.isInitialized) {
+                player = null
+                exoPlayer.setVideoSurface(null)
+                exoPlayer.release()
+            }
+
+            exoPlayer = VideoPlayerHelper.buildPlayer(context, GeneralPrefs)
+            player = exoPlayer
+            player?.addListener(this)
+            player?.repeatMode = Player.REPEAT_MODE_OFF
         }
 
         fun release() {
@@ -328,7 +336,8 @@ class VideoPlayerView
             removeCallbacks(almostFinishedRunnable)
             FirebaseHelper.crashlyticsException(error.cause)
 
-            post(onErrorRunnable)
+            // Allow the TV's asynchronous codec and graphic buffers to finish releasing.
+            postDelayed(onErrorRunnable, 5_000)
         }
 
         override fun onPlayerErrorChanged(error: PlaybackException?) {


### PR DESCRIPTION
## Summary

Recreate the video surface after Media3 reports a decoder error on TCL Google TV devices.

The Realtek decoder can fail during 4K HEVC transitions with `OMX.realtek.video.decoder`, leaving the existing surface black. This change releases the failed player, replaces the video surface, and continues the playlist after the existing recovery delay.

## Validation

- Built `:app:assembleBetaDebug` successfully.
- Installed and tested the canary on a TCL G10 running Android 12.
- Verified 4K Apple HEVC and Dolby Vision playback across multiple sources.
- Verified recovery after repeated forced transitions.

## Device evidence

The failure appeared as `Error 0x80001000`, `Reset failed`, and decoder initialization errors from `OMX.realtek.video.decoder`.
