### PR TITLE
Custom feed audio support

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,6 +685,7 @@ The app supports the "community" video format, which is a JSON file (typically n
       "timeOfDay": "sunset",
       "url-1080-SDR": "https://example.com/videos/sunset_1080p.mp4",
       "url-4K-SDR": "https://example.com/videos/sunset_4k.mp4",
+      "url-audio": "https://example.com/videos/sunset_audio.m4a",
       "pointsOfInterest": {
         "0": "The setting sun",
         "30": "Palm trees swaying in the breeze"
@@ -693,6 +694,8 @@ The app supports the "community" video format, which is a JSON file (typically n
   ]
 }
 ```
+
+The optional `url-audio` field is intended for DASH-style videos from some external providers, where the video and audio streams are encoded seperately. 
 
 Another example [can be found on GitHub](https://github.com/AerialScreensaver/AerialCommunity/blob/master/entries.json).
 

--- a/app/schemas/com.neilturner.aerialviews.data.AerialDatabase/2.json
+++ b/app/schemas/com.neilturner.aerialviews.data.AerialDatabase/2.json
@@ -1,0 +1,266 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "e56dc561cdf4c16ff204fedd058035ce",
+    "entities": [
+      {
+        "tableName": "cached_media",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `playlistOrder` INTEGER NOT NULL, `uri` TEXT NOT NULL, `type` TEXT NOT NULL, `source` TEXT NOT NULL, `shortDescription` TEXT NOT NULL, `pointsOfInterest` TEXT NOT NULL, `timeOfDay` TEXT NOT NULL, `scene` TEXT NOT NULL, `albumName` TEXT NOT NULL, `title` TEXT NOT NULL, `exifDate` TEXT, `exifOffset` TEXT, `exifLatitude` REAL, `exifLongitude` REAL, `exifCity` TEXT, `exifState` TEXT, `exifCountry` TEXT, `exifDescription` TEXT, `audioUri` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistOrder",
+            "columnName": "playlistOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shortDescription",
+            "columnName": "shortDescription",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pointsOfInterest",
+            "columnName": "pointsOfInterest",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeOfDay",
+            "columnName": "timeOfDay",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scene",
+            "columnName": "scene",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumName",
+            "columnName": "albumName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exifDate",
+            "columnName": "exifDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "exifOffset",
+            "columnName": "exifOffset",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "exifLatitude",
+            "columnName": "exifLatitude",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "exifLongitude",
+            "columnName": "exifLongitude",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "exifCity",
+            "columnName": "exifCity",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "exifState",
+            "columnName": "exifState",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "exifCountry",
+            "columnName": "exifCountry",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "exifDescription",
+            "columnName": "exifDescription",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "audioUri",
+            "columnName": "audioUri",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_media_playlistOrder",
+            "unique": false,
+            "columnNames": [
+              "playlistOrder"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_media_playlistOrder` ON `${TABLE_NAME}` (`playlistOrder`)"
+          }
+        ]
+      },
+      {
+        "tableName": "cached_music_tracks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `playlistOrder` INTEGER NOT NULL, `uri` TEXT NOT NULL, `source` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistOrder",
+            "columnName": "playlistOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cached_music_tracks_playlistOrder",
+            "unique": false,
+            "columnNames": [
+              "playlistOrder"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cached_music_tracks_playlistOrder` ON `${TABLE_NAME}` (`playlistOrder`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `mediaPosition` INTEGER NOT NULL, `musicTrackIndex` INTEGER NOT NULL, `cachedAt` INTEGER NOT NULL, `settingsHash` TEXT NOT NULL, `totalMediaItems` INTEGER NOT NULL, `totalMusicTracks` INTEGER NOT NULL, `shuffleEnabled` INTEGER NOT NULL, `musicShuffleEnabled` INTEGER NOT NULL, `musicRepeatEnabled` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaPosition",
+            "columnName": "mediaPosition",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "musicTrackIndex",
+            "columnName": "musicTrackIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "settingsHash",
+            "columnName": "settingsHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalMediaItems",
+            "columnName": "totalMediaItems",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalMusicTracks",
+            "columnName": "totalMusicTracks",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shuffleEnabled",
+            "columnName": "shuffleEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "musicShuffleEnabled",
+            "columnName": "musicShuffleEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "musicRepeatEnabled",
+            "columnName": "musicRepeatEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e56dc561cdf4c16ff204fedd058035ce')"
+    ]
+  }
+}

--- a/app/src/main/java/com/neilturner/aerialviews/data/AerialDatabase.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/data/AerialDatabase.kt
@@ -9,7 +9,7 @@ import androidx.sqlite.driver.AndroidSQLiteDriver
 
 @Database(
     entities = [CachedMediaEntity::class, CachedMusicTrackEntity::class, PlaylistStateEntity::class],
-    version = 1,
+    version = 2,
     exportSchema = true,
 )
 @ColumnTypeConverters(Converters::class)

--- a/app/src/main/java/com/neilturner/aerialviews/data/AerialDatabase.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/data/AerialDatabase.kt
@@ -1,6 +1,7 @@
 package com.neilturner.aerialviews.data
 
 import android.content.Context
+import androidx.room3.AutoMigration
 import androidx.room3.ColumnTypeConverters
 import androidx.room3.Database
 import androidx.room3.Room
@@ -11,6 +12,7 @@ import androidx.sqlite.driver.AndroidSQLiteDriver
     entities = [CachedMediaEntity::class, CachedMusicTrackEntity::class, PlaylistStateEntity::class],
     version = 2,
     exportSchema = true,
+    autoMigrations = [AutoMigration(from = 1, to = 2)],
 )
 @ColumnTypeConverters(Converters::class)
 abstract class AerialDatabase : RoomDatabase() {

--- a/app/src/main/java/com/neilturner/aerialviews/data/CachedMediaEntity.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/data/CachedMediaEntity.kt
@@ -26,4 +26,5 @@ data class CachedMediaEntity(
     val exifState: String?,
     val exifCountry: String?,
     val exifDescription: String?,
+    val audioUri: String? = null,
 )

--- a/app/src/main/java/com/neilturner/aerialviews/data/PlaylistCacheRepository.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/data/PlaylistCacheRepository.kt
@@ -219,6 +219,7 @@ class PlaylistCacheRepository(
                             description = entity.exifDescription,
                         ),
                 ),
+            audioUri = entity.audioUri?.toUri(),
         )
 
     suspend fun cachePlaylist(
@@ -249,6 +250,7 @@ class PlaylistCacheRepository(
                     exifState = m.metadata.exif.state,
                     exifCountry = m.metadata.exif.country,
                     exifDescription = m.metadata.exif.description,
+                    audioUri = m.audioUri?.toString(),
                 )
             }
 

--- a/app/src/main/java/com/neilturner/aerialviews/models/videos/AbstractVideo.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/models/videos/AbstractVideo.kt
@@ -1,6 +1,7 @@
 package com.neilturner.aerialviews.models.videos
 
 import android.net.Uri
+import androidx.core.net.toUri
 import com.neilturner.aerialviews.models.enums.VideoQuality
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -22,6 +23,9 @@ abstract class AbstractVideo {
     @SerialName("url-4K-HDR")
     val video4khdr: String? = null
 
+    @SerialName("url-audio")
+    val audioUrl: String? = null
+
     @SerialName("accessibilityLabel")
     val description: String = ""
 
@@ -30,6 +34,8 @@ abstract class AbstractVideo {
 
     val timeOfDay: String = ""
     val scene: String = ""
+
+    fun audioUri(): Uri? = audioUrl?.takeIf { it.isNotBlank() }?.toUri()
 
     abstract fun uriAtQuality(quality: VideoQuality?): Uri
 

--- a/app/src/main/java/com/neilturner/aerialviews/models/videos/AerialMedia.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/models/videos/AerialMedia.kt
@@ -11,6 +11,7 @@ data class AerialMedia(
     var type: AerialMediaType = AerialMediaType.VIDEO,
     var source: AerialMediaSource = AerialMediaSource.UNKNOWN,
     var metadata: AerialMediaMetadata = AerialMediaMetadata(),
+    var audioUri: Uri? = null,
 )
 
 data class AerialMediaMetadata(

--- a/app/src/main/java/com/neilturner/aerialviews/providers/custom/CustomFeedProvider.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/providers/custom/CustomFeedProvider.kt
@@ -489,6 +489,7 @@ class CustomFeedProvider(
                                         timeOfDay = TimeOfDay.UNKNOWN,
                                         scene = SceneType.UNKNOWN,
                                     ),
+                                audioUri = asset.audioUri(),
                             ),
                         )
                     }

--- a/app/src/main/java/com/neilturner/aerialviews/ui/core/VideoPlayerHelper.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/ui/core/VideoPlayerHelper.kt
@@ -11,6 +11,7 @@ import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.rtsp.RtspMediaSource
+import androidx.media3.exoplayer.source.MergingMediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector.Parameters
@@ -155,7 +156,20 @@ object VideoPlayerHelper {
         player: ExoPlayer,
         media: AerialMedia,
     ) {
-        player.setMediaSource(createMediaSource(context, MediaItem.fromUri(media.uri), media.source))
+        val video = createMediaSource(context, MediaItem.fromUri(media.uri), media.source)
+        val audioUri = media.audioUri
+
+        // Skip playing audio if not enabled or if background music is playing
+        val mediaSource =
+            if (audioUri == null || GeneralPrefs.playsBackgroundMusic) {
+                video
+            } else {
+                Timber.i("Using MergingMediaSource to combine video and audio streams: $audioUri")
+                val audio = createMediaSource(context, MediaItem.fromUri(audioUri), media.source)
+                MergingMediaSource(video, audio)
+            }
+
+        player.setMediaSource(mediaSource)
     }
 
     @OptIn(UnstableApi::class)

--- a/app/src/main/java/com/neilturner/aerialviews/ui/core/VideoPlayerHelper.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/ui/core/VideoPlayerHelper.kt
@@ -155,6 +155,7 @@ object VideoPlayerHelper {
         context: Context,
         player: ExoPlayer,
         media: AerialMedia,
+        includeSeparateAudio: Boolean = true,
     ) {
         val video = createMediaSource(context, MediaItem.fromUri(media.uri), media.source)
         val audioUri = media.audioUri
@@ -162,7 +163,7 @@ object VideoPlayerHelper {
         // Only fetch the extra stream when video audio is the chosen mode, as the
         // muted and background music modes would download it just to silence it
         val mediaSource =
-            if (audioUri == null || !GeneralPrefs.playsVideoAudio) {
+            if (audioUri == null || !includeSeparateAudio || !GeneralPrefs.playsVideoAudio) {
                 video
             } else {
                 Timber.i("Using MergingMediaSource to combine video and audio streams: $audioUri")

--- a/app/src/main/java/com/neilturner/aerialviews/ui/core/VideoPlayerHelper.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/ui/core/VideoPlayerHelper.kt
@@ -159,9 +159,10 @@ object VideoPlayerHelper {
         val video = createMediaSource(context, MediaItem.fromUri(media.uri), media.source)
         val audioUri = media.audioUri
 
-        // Skip playing audio if not enabled or if background music is playing
+        // Only fetch the extra stream when video audio is the chosen mode, as the
+        // muted and background music modes would download it just to silence it
         val mediaSource =
-            if (audioUri == null || GeneralPrefs.playsBackgroundMusic) {
+            if (audioUri == null || !GeneralPrefs.playsVideoAudio) {
                 video
             } else {
                 Timber.i("Using MergingMediaSource to combine video and audio streams: $audioUri")

--- a/app/src/main/java/com/neilturner/aerialviews/ui/core/VideoPlayerView.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/ui/core/VideoPlayerView.kt
@@ -68,6 +68,8 @@ class VideoPlayerView
                 setVolume = { v -> exoPlayer.volume = v },
             )
         private var forcedMuted = false
+        private var currentMedia: AerialMedia? = null
+        private var separateAudioFailed = false
 
         private val progressBar =
             GeneralPrefs.progressBarLocation != ProgressBarLocation.DISABLED && GeneralPrefs.progressBarType != ProgressBarType.PHOTOS
@@ -116,12 +118,15 @@ class VideoPlayerView
             removeCallbacks(onErrorRunnable)
             // Clear listener
             listener = null
+            currentMedia = null
             cancelVolumeFade()
         }
 
         fun setVideo(media: AerialMedia) {
             state = VideoState() // Reset params for each video
             state.type = media.source
+            currentMedia = media
+            separateAudioFailed = false
             cancelVolumeFade()
             resetRotation()
 
@@ -129,7 +134,11 @@ class VideoPlayerView
                 PhilipsMediaCodecAdapterFactory.mediaUrl = media.uri.toString()
             }
 
-            VideoPlayerHelper.setupMediaSource(context, exoPlayer, media)
+            prepareMediaSource(media)
+        }
+
+        private fun prepareMediaSource(media: AerialMedia) {
+            VideoPlayerHelper.setupMediaSource(context, exoPlayer, media, includeSeparateAudio = !separateAudioFailed)
             applyMuteState()
 
             // Disable subtitles/text tracks by default
@@ -334,9 +343,28 @@ class VideoPlayerView
         override fun onPlayerError(error: PlaybackException) {
             super.onPlayerError(error)
             removeCallbacks(almostFinishedRunnable)
+
+            if (retryWithoutSeparateAudio()) return
+
             FirebaseHelper.crashlyticsException(error.cause)
 
             post(onErrorRunnable)
+        }
+
+        // A broken audio stream fails the whole merged source, so give the video
+        // one more chance on its own rather than skipping it entirely
+        private fun retryWithoutSeparateAudio(): Boolean {
+            val media = currentMedia ?: return false
+            if (separateAudioFailed || media.audioUri == null || !GeneralPrefs.playsVideoAudio) {
+                return false
+            }
+
+            Timber.w("Playback failed with a separate audio stream, retrying video only: ${media.audioUri}")
+            separateAudioFailed = true
+            state.prepared = false
+            state.loopCount = 0
+            prepareMediaSource(media)
+            return true
         }
 
         override fun onPlayerErrorChanged(error: PlaybackException?) {

--- a/app/src/test/java/com/neilturner/aerialviews/providers/custom/CustomFeedAudioTest.kt
+++ b/app/src/test/java/com/neilturner/aerialviews/providers/custom/CustomFeedAudioTest.kt
@@ -1,0 +1,102 @@
+package com.neilturner.aerialviews.providers.custom
+
+import android.net.Uri
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkStatic
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class CustomFeedAudioTest {
+    // Mirrors the production JsonHelper configuration used to parse custom feeds
+    private val json =
+        Json {
+            ignoreUnknownKeys = true
+            isLenient = true
+        }
+
+    @BeforeEach
+    fun mockUri() {
+        mockkStatic(Uri::class)
+    }
+
+    @AfterEach
+    fun unmockUri() {
+        unmockkStatic(Uri::class)
+    }
+
+    @Test
+    fun `parses the separate audio url from an asset`() {
+        val body =
+            """
+            {
+              "assets": [
+                {
+                  "id": "sunset-beach",
+                  "accessibilityLabel": "Sunset over the beach",
+                  "url-1080-H264": "https://example.com/video.mp4",
+                  "url-4K-SDR": "https://example.com/video-4k.webm",
+                  "url-audio": "https://example.com/audio.m4a"
+                }
+              ]
+            }
+            """.trimIndent()
+
+        val asset = json.decodeFromString<FeedVideos>(body).assets!!.single()
+
+        assertEquals("https://example.com/audio.m4a", asset.audioUrl)
+    }
+
+    @Test
+    fun `audio url is null when the feed omits it`() {
+        val body = """{ "assets": [ { "url-1080-SDR": "https://example.com/video.mp4" } ] }"""
+
+        val asset = json.decodeFromString<FeedVideos>(body).assets!!.single()
+
+        assertNull(asset.audioUrl)
+        assertNull(asset.audioUri())
+    }
+
+    @Test
+    fun `audio uri is built from the audio url`() {
+        val urlSlot = slot<String>()
+        every { Uri.parse(capture(urlSlot)) } returns mockk(relaxed = true)
+        val body = """{ "assets": [ { "url-audio": "https://example.com/audio.m4a" } ] }"""
+
+        val asset = json.decodeFromString<FeedVideos>(body).assets!!.single()
+
+        asset.audioUri()
+        assertEquals("https://example.com/audio.m4a", urlSlot.captured)
+    }
+
+    @Test
+    fun `blank audio url is treated as absent`() {
+        val body = """{ "assets": [ { "url-audio": "  " } ] }"""
+
+        val asset = json.decodeFromString<FeedVideos>(body).assets!!.single()
+
+        assertNull(asset.audioUri())
+    }
+
+    @Test
+    fun `photos in the same feed are unaffected`() {
+        val body =
+            """
+            {
+              "assets": [ { "url-1080-SDR": "https://example.com/v.mp4", "url-audio": "https://example.com/a.m4a" } ],
+              "photos": [ { "url-1080": "https://example.com/p.jpg", "title": "Photo" } ]
+            }
+            """.trimIndent()
+
+        val feed = json.decodeFromString<FeedVideos>(body)
+
+        assertEquals("https://example.com/a.m4a", feed.assets!!.single().audioUrl)
+        assertEquals("Photo", feed.photos!!.single().title)
+    }
+}


### PR DESCRIPTION
I believe this feature should be fairly straightforward but let me know if it's causing any issues. I've tested in on an emulator and real hardware without seeing any problems. 

## Summary

Some custom feeds serve DASH-style renditions where the video and audio are encoded as separate files, so the video URL on its own plays silently. This adds an optional `url-audio` field to the community feed format and combines the two streams with a `MergingMediaSource` at playback time.

The feature is opt-in per asset. Feeds without `url-audio` behave as before, and the extra stream is only fetched when the user has actually chosen to hear audio from videos.

## Feed format

```json
{
  "assets": [
    {
      "accessibilityLabel": "Sunset over the beach",
      "url-1080-SDR": "https://example.com/videos/sunset_1080p.mp4",
      "url-audio": "https://example.com/videos/sunset_audio.m4a"
    }
  ]
}
```

## Logic flow

```mermaid
flowchart TD
    A["entries.json<br/>optional url-audio"] --> B["AbstractVideo.audioUrl<br/>audioUri() drops blanks"]
    B --> C["CustomFeedProvider<br/>AerialMedia.audioUri"]
    C <--> D[("Room cached_media<br/>audioUri column")]
    C --> E["VideoPlayerView.setVideo"]
    E --> F{"audioUri set and<br/>audio mode is VIDEO_AUDIO?"}
    F -- no --> G["Video only<br/>ProgressiveMediaSource"]
    F -- yes --> H["MergingMediaSource(video, audio)"]
    G --> I["ExoPlayer.prepare"]
    H --> I
    I --> J{"PlaybackException?"}
    J -- "first failure with merged audio" --> K["Re-prepare video only"]
    K --> I
    J -- "no audio merged, or already retried" --> L["onVideoError, skip to next item"]
```

**Parsing.** 

`url-audio` is declared on `AbstractVideo`, the shared base class for the existing feed formats. 

`audioUri()` treats a blank value as absent, causing it to be dropped. 

`CustomFeedProvider.processEntriesUrl` reads it. The existing built-in providers deserialise the field and ignore it. The CSV path has no audio column, and RTSP/HLS streams are assumed to carry their own audio.

**Caching.** 

`PlaylistCacheRepository` round-trips the URI as a string, so a playlist restored from cache keeps its associated audio.

**Playback.** 

`setupMediaSource` wraps both children in a `MergingMediaSource` only when there is an audio URI *and* `playlistAudioMode` is `VIDEO_AUDIO`. The muted and background-music modes cannot play the stream, so skipping the merge avoids downloading and decoding audio (as per the default behaviour of muting all videos).

**Error handling.** 

`MergingMediaSource` would ordinarily propagate load errors from either child, so a broken audio file would take the video down with it. `VideoPlayerView` now re-prepares the video on its own after the first failure of a merged source, restoring the silent playback these feeds had before audio support.

## Changes

**Feed model and provider**
- `AbstractVideo` includes a `@SerialName("url-audio") audioUrl` and an `audioUri()` helper that discards blank values.
- `AerialMedia` includes a nullable `audioUri`, populated by `CustomFeedProvider`.

**Playlist cache**
- `CachedMediaEntity` includes a nullable `audioUri` column. 
- Database version 1 to 2 with `AutoMigration(from = 1, to = 2)`. To preserve existing caches, Room generates a single `ALTER TABLE cached_media ADD COLUMN audioUri TEXT DEFAULT NULL` to migrate; without it the pre-existing `fallbackToDestructiveMigration` would drop the cached playlist, music tracks and resume position on first launch after updating. 
- Schema `2.json` exported and committed.

**Playback**
- `setupMediaSource` takes an `includeSeparateAudio` flag so the view can re-prepare without audio.
- `VideoPlayerView` tracks the current media, extracts the prepare sequence into `prepareMediaSource`, and adds the retry in `onPlayerError`. The retry resets `state.prepared` and `loopCount` so playback parameters are recalculated, but leaves `state.ready` alone so `onVideoPrepared` is not fired twice.

## Notes and trade-offs

- **Runtime unmute.** In `VIDEO_MUTED` mode the remote's mute toggle normally reveals a video's audio mid-playback. For split-track videos there is nothing to unmute, since the stream was never merged. Supporting it would mean always paying the download cost even for users who never unmute.
- **Duration mismatch.** The merge uses the default `clipDurations = false`, so the merged timeline takes its duration from the video. Feeds where the two drift would need `MergingMediaSource(true, true, video, audio)`.

## Testing

`CustomFeedAudioTest` covers the parsing surface against the production `JsonHelper` configuration: the field present, absent, and blank; the URI being built from the URL; and photos in the same feed remaining unaffected.

