### PR TITLE
Add HDR quality options to custom feeds

### DIFF
--- a/app/src/main/java/com/neilturner/aerialviews/models/videos/Comm1Video.kt
+++ b/app/src/main/java/com/neilturner/aerialviews/models/videos/Comm1Video.kt
@@ -10,11 +10,14 @@ import kotlin.enums.enumEntries
 @Serializable
 class Comm1Video : AbstractVideo() {
     override fun uriAtQuality(quality: VideoQuality?): Uri {
+        // Not every entry in a feed has an HDR rendition, so selecting HDR falls back to SDR at the same size
         val url =
             when (quality) {
                 VideoQuality.VIDEO_1080_SDR -> video1080sdr
                 VideoQuality.VIDEO_4K_SDR -> video4ksdr
                 VideoQuality.VIDEO_1080_H264 -> video1080h264
+                VideoQuality.VIDEO_1080_HDR -> video1080hdr?.takeIf { it.isNotBlank() } ?: video1080sdr
+                VideoQuality.VIDEO_4K_HDR -> video4khdr?.takeIf { it.isNotBlank() } ?: video4ksdr
                 else -> video1080h264
             }.toString()
         return url.toUri()

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -203,12 +203,16 @@
     <string-array name="custom_feed_quality_entries" translatable="false">
         <item>1080p H.264</item>
         <item>1080p HEVC</item>
+        <item>1080p HDR</item>
         <item>4K HEVC</item>
+        <item>4K HDR</item>
     </string-array>
     <string-array name="custom_feed_quality_values" translatable="false">
         <item>VIDEO_1080_H264</item>
         <item>VIDEO_1080_SDR</item>
+        <item>VIDEO_1080_HDR</item>
         <item>VIDEO_4K_SDR</item>
+        <item>VIDEO_4K_HDR</item>
     </string-array>
     <string name="custom_feed_quality_default" translatable="false">VIDEO_1080_SDR</string>
 

--- a/app/src/test/java/com/neilturner/aerialviews/providers/custom/CustomFeedHdrTest.kt
+++ b/app/src/test/java/com/neilturner/aerialviews/providers/custom/CustomFeedHdrTest.kt
@@ -1,0 +1,123 @@
+package com.neilturner.aerialviews.providers.custom
+
+import android.net.Uri
+import com.neilturner.aerialviews.models.enums.VideoQuality
+import com.neilturner.aerialviews.models.videos.Comm1Video
+import io.mockk.CapturingSlot
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkStatic
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class CustomFeedHdrTest {
+    // Mirrors the production JsonHelper configuration used to parse custom feeds
+    private val json =
+        Json {
+            ignoreUnknownKeys = true
+            isLenient = true
+        }
+
+    private lateinit var urlSlot: CapturingSlot<String>
+
+    private val allQualities =
+        """
+        {
+          "assets": [
+            {
+              "id": "night-walk",
+              "url-1080-H264": "https://example.com/1080-h264.mp4",
+              "url-1080-SDR": "https://example.com/1080-sdr.webm",
+              "url-1080-HDR": "https://example.com/1080-hdr.webm",
+              "url-4K-SDR": "https://example.com/4k-sdr.webm",
+              "url-4K-HDR": "https://example.com/4k-hdr.webm"
+            }
+          ]
+        }
+        """.trimIndent()
+
+    @BeforeEach
+    fun mockUri() {
+        mockkStatic(Uri::class)
+        urlSlot = slot()
+        every { Uri.parse(capture(urlSlot)) } returns mockk(relaxed = true)
+    }
+
+    @AfterEach
+    fun unmockUri() {
+        unmockkStatic(Uri::class)
+    }
+
+    private fun assetFrom(body: String): Comm1Video = json.decodeFromString<FeedVideos>(body).assets!!.single()
+
+    @Test
+    fun `1080p HDR selects the 1080p HDR rendition`() {
+        assetFrom(allQualities).uriAtQuality(VideoQuality.VIDEO_1080_HDR)
+
+        assertEquals("https://example.com/1080-hdr.webm", urlSlot.captured)
+    }
+
+    @Test
+    fun `4K HDR selects the 4K HDR rendition`() {
+        assetFrom(allQualities).uriAtQuality(VideoQuality.VIDEO_4K_HDR)
+
+        assertEquals("https://example.com/4k-hdr.webm", urlSlot.captured)
+    }
+
+    @Test
+    fun `4K HDR falls back to 4K SDR when the feed has no HDR rendition`() {
+        val body =
+            """
+            {
+              "assets": [
+                {
+                  "url-1080-H264": "https://example.com/1080-h264.mp4",
+                  "url-4K-SDR": "https://example.com/4k-sdr.webm"
+                }
+              ]
+            }
+            """.trimIndent()
+
+        assetFrom(body).uriAtQuality(VideoQuality.VIDEO_4K_HDR)
+
+        assertEquals("https://example.com/4k-sdr.webm", urlSlot.captured)
+    }
+
+    @Test
+    fun `1080p HDR falls back to 1080p SDR when the HDR url is blank`() {
+        val body =
+            """
+            {
+              "assets": [
+                {
+                  "url-1080-SDR": "https://example.com/1080-sdr.webm",
+                  "url-1080-HDR": "   "
+                }
+              ]
+            }
+            """.trimIndent()
+
+        assetFrom(body).uriAtQuality(VideoQuality.VIDEO_1080_HDR)
+
+        assertEquals("https://example.com/1080-sdr.webm", urlSlot.captured)
+    }
+
+    @Test
+    fun `SDR selections are unchanged by the HDR branches`() {
+        val asset = assetFrom(allQualities)
+
+        asset.uriAtQuality(VideoQuality.VIDEO_1080_SDR)
+        assertEquals("https://example.com/1080-sdr.webm", urlSlot.captured)
+
+        asset.uriAtQuality(VideoQuality.VIDEO_4K_SDR)
+        assertEquals("https://example.com/4k-sdr.webm", urlSlot.captured)
+
+        asset.uriAtQuality(VideoQuality.VIDEO_1080_H264)
+        assertEquals("https://example.com/1080-h264.mp4", urlSlot.captured)
+    }
+}


### PR DESCRIPTION
## Summary

Custom feeds could already declare `url-1080-HDR` and `url-4K-HDR`, and the app was already parsing both fields, but the values were then discarded and the user was never offered HDR. 

Hence, selecting a quality in the custom feed settings would always resolve to the SDR version.

Two things caused this:

- `custom_feed_quality_entries` only listed `VIDEO_1080_H264`, `VIDEO_1080_SDR` and `VIDEO_4K_SDR`, so HDR was not selectable.
- `Comm1Video.uriAtQuality` had no HDR branch. Had the preference somehow held an HDR value, it would have fallen through `else -> video1080h264` and silently played 1080p H.264.

This adds the two missing options and the two missing branches. Feeds that don't publish HDR versions are unaffected.

## Changes

**Quality options** 
`arrays.xml` now has 1080p HDR / `VIDEO_1080_HDR` and 4K HDR / `VIDEO_4K_HDR` options. The existing default (`VIDEO_1080_SDR`) is unchanged.

**Rendition selection** 
`Comm1Video.uriAtQuality` resolves the two HDR qualities, each falling back to the SDR rendition at the same resolution when the entry has no HDR URL.

HDR renditions are normally per-asset rather than per-feed: on the feed I tested against, 9 of 126 entries have no HDR URL. Without a fallback those entries hit the existing `.toString()` on a nullable `String?` and produce the literal URI `"null"`, which fails to load and skips the item.

A blank string is treated the same as absent, matching how `audioUri()` already handles blank values.

One side effect worth flagging: `allUrls()` enumerates every `VideoQuality` to build the keys for the points-of-interest and description lookup, so HDR URLs now contribute keys too. For feeds whose renditions share a basename this is a no-op after the set dedupes. For feeds whose HDR files are named differently it means metadata now matches when a viewer is watching HDR, which previously it would not have.

## Notes and trade-offs

- **No HDR capability notice.** 
`AppleVideosFragment` shows a warning when Dolby Vision is selected on a display that doesn't report support for it. There is no equivalent here. A custom-feed version would need to check for `HDR10`/`HLG` rather than `DOLBY_VISION`, since that is what non-Apple feeds typically carry.

Given that HDR10 and HLG is more widely supported than Dolby Vision, I've opted against it, but I'm happy to add it if needed.

- **No data usage estimate.** 
The custom feed screen uses a plain `ListPreference` rather than `MediaPreferenceHelper.setupQualityWithDataUsage`, so unlike the Apple and Amazon screens it shows no bandwidth hint. 4K HDR is the heaviest option by a wide margin — on the feed I measured, a median of roughly 13 GB/hour against 11.8 for 4K SDR and 3.1 for 1080p HDR. 

- **Tone mapping.** Playback does no tone mapping, so on a display without HDR support these renditions render with the usual flat, desaturated look. That is pre-existing behaviour shared with the Apple Dolby Vision options rather than anything new here.

## Testing

`CustomFeedHdrTest` covers rendition selection against the production `JsonHelper` configuration: both HDR qualities resolving to their own URL, the fallback to SDR when the HDR URL is missing and when it is blank, and the three SDR qualities being unchanged by the new branches.

Verified on an Android TV 4K emulator (API 36, Media3 1.11.1) against a live feed of 126 entries:

- The provider logged `126 VIDEO_1080_HDR videos found`, and the quality dialog rendered all five options with the selection persisting correctly.
- 1080p HDR loaded the expected rendition at 1920x1080 with HDR signalling intact — `color=BT2020/Limited range/ST2084 PQ`, `supported=YES` — and reached `Ready, Playing`.
- 4K HDR loaded its own distinct rendition at 3840x2160 with the same colour signalling.

The emulator can't confirm HDR actually reaches the panel (it reports no HDR display and logs `Failed to initialize 101010-2 format`), so this verifies rendition selection, container/codec handling and decoder setup rather than HDR output itself. 

Still need to confirm on actual hardware. 

`:app:testBetaDebugUnitTest`, `:app:lintKotlin` and `:app:assembleBetaDebug` all pass.
